### PR TITLE
add esplora url

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The following environment variables can be configured:
 | `FULMINE_HTTP_PORT` | HTTP port for the web UI and REST API | `7001` |
 | `FULMINE_GRPC_PORT` | gRPC port for service communication | `7000` |
 | `FULMINE_ARK_SERVER` | URL of the Ark server to connect to | It pre-fills with the default Ark server |
+| `FULMINE_ESPLORA_URL` | URL of the Esplora server to connect to | It pre-fills with the default Esplora server |
 
 When using Docker, you can set these variables using the `-e` flag:
 
@@ -64,6 +65,7 @@ docker run -d \
   -p 7001:7001 \
   -e FULMINE_HTTP_PORT=7001 \
   -e FULMINE_ARK_SERVER="https://server.example.com" \
+  -e FULMINE_ESPLORA_URL="https://mempool.space/api" \
   -v fulmine-data:/app/data \
   ghcr.io/arklabshq/fulmine:latest
 ```

--- a/cmd/fulmine/main.go
+++ b/cmd/fulmine/main.go
@@ -87,6 +87,7 @@ func main() {
 		vtxoRolloverRepo,
 		schedulerSvc,
 		lnSvc,
+		cfg.EsploraURL,
 	)
 	if err != nil {
 		log.WithError(err).Fatal(err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,16 +19,18 @@ type Config struct {
 	WithTLS    bool
 	LogLevel   uint32
 	ArkServer  string
+	EsploraURL string
 	CLNDatadir string // for testing purposes only
 }
 
 var (
-	Datadir   = "DATADIR"
-	GRPCPort  = "GRPC_PORT"
-	HTTPPort  = "HTTP_PORT"
-	WithTLS   = "NO_TLS"
-	LogLevel  = "LOG_LEVEL"
-	ArkServer = "ARK_SERVER"
+	Datadir    = "DATADIR"
+	GRPCPort   = "GRPC_PORT"
+	HTTPPort   = "HTTP_PORT"
+	WithTLS    = "NO_TLS"
+	LogLevel   = "LOG_LEVEL"
+	ArkServer  = "ARK_SERVER"
+	EsploraURL = "ESPLORA_URL"
 
 	// Only for testing purposes
 	CLNDatadir = "CLN_DATADIR"
@@ -63,6 +65,7 @@ func LoadConfig() (*Config, error) {
 		WithTLS:    viper.GetBool(WithTLS),
 		LogLevel:   viper.GetUint32(LogLevel),
 		ArkServer:  viper.GetString(ArkServer),
+		EsploraURL: viper.GetString(EsploraURL),
 		CLNDatadir: cleanAndExpandPath(viper.GetString(CLNDatadir)),
 	}, nil
 }

--- a/internal/core/domain/settings.go
+++ b/internal/core/domain/settings.go
@@ -5,6 +5,7 @@ import "context"
 type Settings struct {
 	ApiRoot     string
 	ServerUrl   string
+	EsploraUrl  string
 	Currency    string
 	EventServer string
 	FullNode    string


### PR DESCRIPTION
This commit adds a `FULMINE_ESPLORA_URL` to being able to override `arksdk` with it. This is useful in regtest and with custom docker networks.
