### PR TITLE
Explicitly enable collaborative exit and onboarding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,9 @@ lint:
 ## run: run in dev mode
 run: clean build-static-assets
 	@echo "Running fulmine in dev mode..."
-	@go run ./cmd/fulmine
+	@export FULMINE_LOG_LEVEL=5; \
+	export FULMINE_WITH_COLLABORATIVE_EXIT=true; \
+	go run ./cmd/fulmine
 
 run-cln: clean build-static-assets
 	@echo "Running fulmine in dev mode with CLN support..."

--- a/cmd/fulmine/main.go
+++ b/cmd/fulmine/main.go
@@ -41,9 +41,10 @@ func main() {
 	log.Info("starting fulmine...")
 
 	svcConfig := grpcservice.Config{
-		GRPCPort: cfg.GRPCPort,
-		HTTPPort: cfg.HTTPPort,
-		WithTLS:  cfg.WithTLS,
+		GRPCPort:              cfg.GRPCPort,
+		HTTPPort:              cfg.HTTPPort,
+		WithTLS:               cfg.WithTLS,
+		WithCollaborativeExit: cfg.WithCollaborativeExit,
 	}
 
 	storeCfg := store.Config{
@@ -74,7 +75,8 @@ func main() {
 	lnSvc := lnd.NewService()
 
 	appSvc, err := application.NewService(
-		buildInfo, storeCfg, storeSvc, dbSvc, schedulerSvc, lnSvc, cfg.EsploraURL,
+		buildInfo, storeCfg, storeSvc, dbSvc, schedulerSvc, lnSvc,
+		cfg.EsploraURL, cfg.WithCollaborativeExit,
 	)
 	if err != nil {
 		log.WithError(err).Fatal(err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,29 +16,31 @@ import (
 )
 
 type Config struct {
-	Datadir          string
-	GRPCPort         uint32
-	HTTPPort         uint32
-	WithTLS          bool
-	LogLevel         uint32
-	ArkServer        string
-	EsploraURL       string
-	CLNDatadir       string // for testing purposes only
-	UnlockerType     string
-	UnlockerFilePath string
-	UnlockerPassword string
+	Datadir               string
+	GRPCPort              uint32
+	HTTPPort              uint32
+	WithTLS               bool
+	LogLevel              uint32
+	ArkServer             string
+	EsploraURL            string
+	CLNDatadir            string // for testing purposes only
+	UnlockerType          string
+	UnlockerFilePath      string
+	UnlockerPassword      string
+	WithCollaborativeExit bool
 
 	unlocker ports.Unlocker
 }
 
 var (
-	Datadir    = "DATADIR"
-	GRPCPort   = "GRPC_PORT"
-	HTTPPort   = "HTTP_PORT"
-	WithTLS    = "WITH_TLS"
-	LogLevel   = "LOG_LEVEL"
-	ArkServer  = "ARK_SERVER"
-	EsploraURL = "ESPLORA_URL"
+	Datadir               = "DATADIR"
+	GRPCPort              = "GRPC_PORT"
+	HTTPPort              = "HTTP_PORT"
+	WithTLS               = "WITH_TLS"
+	LogLevel              = "LOG_LEVEL"
+	ArkServer             = "ARK_SERVER"
+	EsploraURL            = "ESPLORA_URL"
+	WithCollaborativeExit = "WITH_COLLABORATIVE_EXIT"
 
 	// Only for testing purposes
 	CLNDatadir = "CLN_DATADIR"
@@ -48,12 +50,13 @@ var (
 	UnlockerFilePath = "UNLOCKER_FILE_PATH"
 	UnlockerPassword = "UNLOCKER_PASSWORD"
 
-	defaultDatadir   = appDatadir("fulmine", false)
-	defaultGRPCPort  = 7000
-	defaultHTTPPort  = 7001
-	defaultWithTLS   = false
-	defaultLogLevel  = 4
-	defaultArkServer = ""
+	defaultDatadir               = appDatadir("fulmine", false)
+	defaultGRPCPort              = 7000
+	defaultHTTPPort              = 7001
+	defaultWithTLS               = false
+	defaultLogLevel              = 4
+	defaultArkServer             = ""
+	defaultWithCollaborativeExit = false
 )
 
 func LoadConfig() (*Config, error) {
@@ -66,23 +69,25 @@ func LoadConfig() (*Config, error) {
 	viper.SetDefault(WithTLS, defaultWithTLS)
 	viper.SetDefault(LogLevel, defaultLogLevel)
 	viper.SetDefault(ArkServer, defaultArkServer)
+	viper.SetDefault(WithCollaborativeExit, defaultWithCollaborativeExit)
 
 	if err := initDatadir(); err != nil {
 		return nil, fmt.Errorf("error while creating datadir: %s", err)
 	}
 
 	config := &Config{
-		Datadir:          viper.GetString(Datadir),
-		GRPCPort:         viper.GetUint32(GRPCPort),
-		HTTPPort:         viper.GetUint32(HTTPPort),
-		WithTLS:          viper.GetBool(WithTLS),
-		LogLevel:         viper.GetUint32(LogLevel),
-		ArkServer:        viper.GetString(ArkServer),
-		EsploraURL:       viper.GetString(EsploraURL),
-		CLNDatadir:       cleanAndExpandPath(viper.GetString(CLNDatadir)),
-		UnlockerType:     viper.GetString(UnlockerType),
-		UnlockerFilePath: viper.GetString(UnlockerFilePath),
-		UnlockerPassword: viper.GetString(UnlockerPassword),
+		Datadir:               viper.GetString(Datadir),
+		GRPCPort:              viper.GetUint32(GRPCPort),
+		HTTPPort:              viper.GetUint32(HTTPPort),
+		WithTLS:               viper.GetBool(WithTLS),
+		LogLevel:              viper.GetUint32(LogLevel),
+		ArkServer:             viper.GetString(ArkServer),
+		EsploraURL:            viper.GetString(EsploraURL),
+		CLNDatadir:            cleanAndExpandPath(viper.GetString(CLNDatadir)),
+		UnlockerType:          viper.GetString(UnlockerType),
+		UnlockerFilePath:      viper.GetString(UnlockerFilePath),
+		UnlockerPassword:      viper.GetString(UnlockerPassword),
+		WithCollaborativeExit: viper.GetBool(WithCollaborativeExit),
 	}
 
 	if err := config.initUnlockerService(); err != nil {

--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -371,15 +371,10 @@ func (s *Service) GetAddress(ctx context.Context, sats uint64) (string, string, 
 	if err != nil {
 		return "", "", "", "", err
 	}
-	bip21Addr := fmt.Sprintf("bitcoin:%s?ark=%s", boardingAddr, offchainAddr)
 
+	bip21Addr := fmt.Sprintf("bitcoin:%s?ark=%s", boardingAddr, offchainAddr)
 	if !s.withCollaborativeExit {
-		bip21Addr := fmt.Sprintf("bitcoin:?ark=%s", offchainAddr)
-		if sats > 0 {
-			btc := float64(sats) / 100000000.0
-			amount := fmt.Sprintf("%.8f", btc)
-			bip21Addr += fmt.Sprintf("&amount=%s", amount)
-		}
+		bip21Addr = fmt.Sprintf("bitcoin:?ark=%s", offchainAddr)
 		boardingAddr = ""
 	}
 

--- a/internal/interface/grpc/config.go
+++ b/internal/interface/grpc/config.go
@@ -7,9 +7,10 @@ import (
 )
 
 type Config struct {
-	GRPCPort uint32
-	HTTPPort uint32
-	WithTLS  bool
+	GRPCPort              uint32
+	HTTPPort              uint32
+	WithTLS               bool
+	WithCollaborativeExit bool
 }
 
 func (c Config) Validate() error {

--- a/internal/interface/grpc/handlers/service_handler.go
+++ b/internal/interface/grpc/handlers/service_handler.go
@@ -14,10 +14,12 @@ import (
 
 type serviceHandler struct {
 	svc *application.Service
+
+	withCollaborativeExit bool
 }
 
-func NewServiceHandler(svc *application.Service) pb.ServiceServer {
-	return &serviceHandler{svc}
+func NewServiceHandler(svc *application.Service, withCollaborativeExit bool) pb.ServiceServer {
+	return &serviceHandler{svc, withCollaborativeExit}
 }
 
 func (h *serviceHandler) GetAddress(
@@ -69,6 +71,10 @@ func (h *serviceHandler) GetInfo(
 func (h *serviceHandler) GetOnboardAddress(
 	ctx context.Context, req *pb.GetOnboardAddressRequest,
 ) (*pb.GetOnboardAddressResponse, error) {
+	if !h.withCollaborativeExit {
+		return nil, status.Error(codes.Unavailable, "operation not allowed")
+	}
+
 	_, _, addr, _, err := h.svc.GetAddress(ctx, 0)
 	if err != nil {
 		return nil, err
@@ -175,6 +181,10 @@ func (h *serviceHandler) SendOffChain(
 func (h *serviceHandler) SendOnChain(
 	ctx context.Context, req *pb.SendOnChainRequest,
 ) (*pb.SendOnChainResponse, error) {
+	if !h.withCollaborativeExit {
+		return nil, status.Error(codes.Unavailable, "operation not allowed")
+	}
+
 	address, err := parseAddress(req.GetAddress())
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())

--- a/internal/interface/grpc/service.go
+++ b/internal/interface/grpc/service.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"github.com/ArkLabsHQ/fulmine/internal/core/ports"
 	"net"
 	"net/http"
 
 	pb "github.com/ArkLabsHQ/fulmine/api-spec/protobuf/gen/go/fulmine/v1"
 	"github.com/ArkLabsHQ/fulmine/internal/core/application"
+	"github.com/ArkLabsHQ/fulmine/internal/core/ports"
 	"github.com/ArkLabsHQ/fulmine/internal/interface/grpc/handlers"
 	"github.com/ArkLabsHQ/fulmine/internal/interface/grpc/interceptors"
 	"github.com/ArkLabsHQ/fulmine/internal/interface/web"
@@ -61,7 +61,7 @@ func NewService(cfg Config, appSvc *application.Service, unlockerSvc ports.Unloc
 	walletHandler := handlers.NewWalletHandler(appSvc)
 	pb.RegisterWalletServiceServer(grpcServer, walletHandler)
 
-	serviceHandler := handlers.NewServiceHandler(appSvc)
+	serviceHandler := handlers.NewServiceHandler(appSvc, cfg.WithCollaborativeExit)
 	pb.RegisterServiceServer(grpcServer, serviceHandler)
 
 	notificationHandler := handlers.NewNotificationHandler(appSvc, appStopCh)
@@ -113,7 +113,7 @@ func NewService(cfg Config, appSvc *application.Service, unlockerSvc ports.Unloc
 		return nil, err
 	}
 
-	feHandler := web.NewService(appSvc, feStopCh)
+	feHandler := web.NewService(appSvc, feStopCh, cfg.WithCollaborativeExit)
 
 	mux := http.NewServeMux()
 	mux.Handle("/", feHandler)

--- a/internal/interface/web/handlers.go
+++ b/internal/interface/web/handlers.go
@@ -392,6 +392,11 @@ func (s *service) sendConfirm(c *gin.Context) {
 	}
 
 	if utils.IsValidBtcAddress(address) {
+		if !s.withCollaborativeExit {
+			toast := components.Toast("operation not allowed", true)
+			toastHandler(toast, c)
+			return
+		}
 		txId, err = s.svc.CollaborativeExit(c, address, value, false)
 		if err != nil {
 			toast := components.Toast(err.Error(), true)

--- a/internal/interface/web/server.go
+++ b/internal/interface/web/server.go
@@ -54,11 +54,14 @@ func (t *TemplRender) Instance(name string, data interface{}) render.Render {
 
 type service struct {
 	*gin.Engine
-	svc    *application.Service
-	stopCh chan struct{}
+	svc                   *application.Service
+	stopCh                chan struct{}
+	withCollaborativeExit bool
 }
 
-func NewService(appSvc *application.Service, stopCh chan struct{}) *service {
+func NewService(
+	appSvc *application.Service, stopCh chan struct{}, withCollaborativeExit bool,
+) *service {
 	// Create a new Fiber server.
 	router := gin.Default()
 
@@ -66,7 +69,7 @@ func NewService(appSvc *application.Service, stopCh chan struct{}) *service {
 	router.HTMLRender = &TemplRender{}
 	staticFS, _ := fs.Sub(static, "static")
 
-	svc := &service{router, appSvc, stopCh}
+	svc := &service{router, appSvc, stopCh, withCollaborativeExit}
 
 	// Handle static files.
 	// svc.Static("/static", "./static")


### PR DESCRIPTION
This adds a new env var FULMINE_WITH_COLLABORATIVE_EXIT that is set to `false` by default so that collaborative exit and onboarding are disabled.

NOTE: By default the bip21 address generated by the fulmine doesn't contain the boarding (onchain) address. It is enabled in dev env by explicitly setting the env var to true.

Please @bordalix @tiero review