### PR TITLE
Fallback to client init only if required otherwise return error

### DIFF
--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -126,6 +126,8 @@ func NewService(
 		}
 
 		return svc, nil
+	} else if !strings.Contains(err.Error(), "not initialized") {
+		return nil, err
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
This makes sure to return error at startup instead of falling back to client initialization if the error returned by `LoadArkClient` is not `client not initialized`.

Please @bordalix review.