### PR TITLE
Fix sentry init

### DIFF
--- a/cmd/fulmine/main.go
+++ b/cmd/fulmine/main.go
@@ -48,6 +48,7 @@ func main() {
 			Dsn:              sentryDsn,
 			Environment:      "prod",
 			AttachStacktrace: true,
+			Release:          version,
 		}); err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
This sets fulmine's version as sentry release to get rid of the warning msg at startup saying a sentry release is missing.

