### PR TITLE
fix pagination

### DIFF
--- a/internal/interface/web/templates/components/history.templ
+++ b/internal/interface/web/templates/components/history.templ
@@ -140,17 +140,24 @@ templ HistoryEmpty() {
 	</div>
 }
 
-templ HistoryBodyContent(transactions []types.Transaction, loadMore bool) {
-	if len(transactions) == 0 {
-    @HistoryEmpty()
-	} else {
-	  for _, tx := range transactions {
-	  	@HistoryLine(tx)
-	  }
-		if loadMore {
-			<div class="flex justify-center" hx-get={"/txs/" + transactions[len(transactions)-1].Txid} hx-swap="outerHTML">
-				<p class="cursor-pointer p-3 text-semibold text-sm text-white/50 hover:text-white/80">Load more</p>
-			</div>
+templ HistoryBodyContent(transactions []types.Transaction, lastTxId string, loadMore bool) {
+	<div
+	  id="txs"
+		hx-get={"/txs/" + lastTxId}
+		hx-trigger="sse:TXS_ADDED, sse:TXS_CONFIRMED, sse:TXS_REPLACED"
+		hx-swap="outerHTML"
+	>
+		if len(transactions) == 0 {
+			@HistoryEmpty()
+		} else {
+			for _, tx := range transactions {
+				@HistoryLine(tx)
+			}
+			if loadMore {
+				<div class="flex justify-center" hx-get={"/txs/" + lastTxId} hx-target="#txs">
+					<p class="cursor-pointer p-3 text-semibold text-sm text-white/50 hover:text-white/80">Load more</p>
+				</div>
+			}
 		}
-	}
+	</div>
 }

--- a/internal/interface/web/templates/components/history_templ.go
+++ b/internal/interface/web/templates/components/history_templ.go
@@ -375,7 +375,7 @@ func HistoryEmpty() templ.Component {
 	})
 }
 
-func HistoryBodyContent(transactions []types.Transaction, loadMore bool) templ.Component {
+func HistoryBodyContent(transactions []types.Transaction, lastTxId string, loadMore bool) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -396,6 +396,23 @@ func HistoryBodyContent(transactions []types.Transaction, loadMore bool) templ.C
 			templ_7745c5c3_Var16 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "<div id=\"txs\" hx-get=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var17 string
+		templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs("/txs/" + lastTxId)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/components/history.templ`, Line: 146, Col: 28}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "\" hx-trigger=\"sse:TXS_ADDED, sse:TXS_CONFIRMED, sse:TXS_REPLACED\" hx-swap=\"outerHTML\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		if len(transactions) == 0 {
 			templ_7745c5c3_Err = HistoryEmpty().Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
@@ -408,29 +425,33 @@ func HistoryBodyContent(transactions []types.Transaction, loadMore bool) templ.C
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, " ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, " ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if loadMore {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "<div class=\"flex justify-center\" hx-get=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "<div class=\"flex justify-center\" hx-get=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var17 string
-				templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs("/txs/" + transactions[len(transactions)-1].Txid)
+				var templ_7745c5c3_Var18 string
+				templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs("/txs/" + lastTxId)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/components/history.templ`, Line: 151, Col: 92}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/components/history.templ`, Line: 157, Col: 63}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "\" hx-swap=\"outerHTML\"><p class=\"cursor-pointer p-3 text-semibold text-sm text-white/50 hover:text-white/80\">Load more</p></div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "\" hx-target=\"#txs\"><p class=\"cursor-pointer p-3 text-semibold text-sm text-white/50 hover:text-white/80\">Load more</p></div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
 		}
 		return nil
 	})

--- a/internal/interface/web/templates/pages/index.templ
+++ b/internal/interface/web/templates/pages/index.templ
@@ -3,6 +3,6 @@ package pages
 templ IndexBodyContent() {
 	<div hx-ext="sse" sse-connect="/events">
 	  <div hx-get="/hero" hx-trigger="load, sse:TXS_ADDED, sse:TXS_CONFIRMED, sse:TXS_REPLACED" />
-	  <div hx-get="/txs/0" hx-trigger="load, sse:TXS_ADDED, sse:TXS_CONFIRMED, sse:TXS_REPLACED" />
+	  <div hx-get="/txs/0" hx-trigger="load, sse:TXS_ADDED, sse:TXS_CONFIRMED, sse:TXS_REPLACED" hx-swap="outerHTML" />
 	</div>
 }

--- a/internal/interface/web/templates/pages/index_templ.go
+++ b/internal/interface/web/templates/pages/index_templ.go
@@ -29,7 +29,7 @@ func IndexBodyContent() templ.Component {
 			templ_7745c5c3_Var1 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div hx-ext=\"sse\" sse-connect=\"/events\"><div hx-get=\"/hero\" hx-trigger=\"load, sse:TXS_ADDED, sse:TXS_CONFIRMED, sse:TXS_REPLACED\"></div><div hx-get=\"/txs/0\" hx-trigger=\"load, sse:TXS_ADDED, sse:TXS_CONFIRMED, sse:TXS_REPLACED\"></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div hx-ext=\"sse\" sse-connect=\"/events\"><div hx-get=\"/hero\" hx-trigger=\"load, sse:TXS_ADDED, sse:TXS_CONFIRMED, sse:TXS_REPLACED\"></div><div hx-get=\"/txs/0\" hx-trigger=\"load, sse:TXS_ADDED, sse:TXS_CONFIRMED, sse:TXS_REPLACED\" hx-swap=\"outerHTML\"></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
This PR fixes a bug in pagination:
- when the app receives a new tx, the tx list pagination was reseted (i.e. only tx from page 1)

With this PR a new unintended behaviour happens, but I think is better than before:
- when the app receives a new tx, a new page of the tx list is fetched

@altafan please review