### PR TITLE
better ux for server not found

### DIFF
--- a/internal/interface/web/handlers.go
+++ b/internal/interface/web/handlers.go
@@ -163,9 +163,8 @@ func (s *service) initialize(c *gin.Context) {
 
 	if err := s.svc.Setup(c, serverUrl, password, privateKey); err != nil {
 		log.WithError(err).Warn("failed to initialize")
-		toast := components.Toast(err.Error(), true)
-		toastHandler(toast, c)
-		return
+		errorContent := components.Error("Server not found", "Please try again")
+		partialViewHandler(errorContent, c)
 	}
 
 	redirect("/done", c)

--- a/internal/interface/web/templates/components/typography.templ
+++ b/internal/interface/web/templates/components/typography.templ
@@ -3,3 +3,12 @@ package components
 templ Label(text string) {
   <p class="font-semibold mb-2 mt-4">{text}</p>
 }
+
+templ Error(line1 string, line2 string) {
+  <div class="border border-1 border-red/20 bg-errorbg capitalize text-center text-red px-2 py-1 rounded-md mx-auto">
+    <p>{line1}</p>
+    if len(line2) > 0 {
+      <p class="mt-1">{line2}</p>
+    }
+  </div>
+}

--- a/internal/interface/web/templates/components/typography_templ.go
+++ b/internal/interface/web/templates/components/typography_templ.go
@@ -50,4 +50,69 @@ func Label(text string) templ.Component {
 	})
 }
 
+func Error(line1 string, line2 string) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var3 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var3 == nil {
+			templ_7745c5c3_Var3 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div class=\"border border-1 border-red/20 bg-errorbg capitalize text-center text-red px-2 py-1 rounded-md mx-auto\"><p>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var4 string
+		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(line1)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/components/typography.templ`, Line: 9, Col: 13}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</p>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if len(line2) > 0 {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<p class=\"mt-1\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var5 string
+			templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(line2)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/components/typography.templ`, Line: 11, Col: 28}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</p>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
 var _ = templruntime.GeneratedTemplate

--- a/internal/interface/web/templates/pages/serverurl.templ
+++ b/internal/interface/web/templates/pages/serverurl.templ
@@ -5,7 +5,7 @@ import (
 )
 
 templ ServerUrlBodyContent(serverUrl, privateKey, password string) {
-  <form hx-post="/initialize">
+  <form hx-post="/initialize" hx-target="#serverUrlError" hx-swap="innerHTML">
     <input type="hidden" name="privateKey" value={privateKey}/>
     <input type="hidden" name="password" value={password}/>
     <div class="flex flex-col justify-between h-screen md:max-w-96 mx-auto p-3">
@@ -15,6 +15,7 @@ templ ServerUrlBodyContent(serverUrl, privateKey, password string) {
 	  		<p class="mb-10">Choose your Server</p>
         <p class="mb-2">Server URL</p>
         @components.InputWithPaste("serverUrl", "", serverUrl)
+				<div id="serverUrlError" class="mt-4"></div>
       </div>
 	  	@components.CreateWalletButton(true)
     </div>

--- a/internal/interface/web/templates/pages/serverurl_templ.go
+++ b/internal/interface/web/templates/pages/serverurl_templ.go
@@ -33,7 +33,7 @@ func ServerUrlBodyContent(serverUrl, privateKey, password string) templ.Componen
 			templ_7745c5c3_Var1 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<form hx-post=\"/initialize\"><input type=\"hidden\" name=\"privateKey\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<form hx-post=\"/initialize\" hx-target=\"#serverUrlError\" hx-swap=\"innerHTML\"><input type=\"hidden\" name=\"privateKey\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -83,7 +83,7 @@ func ServerUrlBodyContent(serverUrl, privateKey, password string) templ.Componen
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<div id=\"serverUrlError\" class=\"mt-4\"></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
If the user inserts a valid URL but not a server's URL, he gets a better warning.

closes #161 

@altafan please review

final result:

<img width="809" alt="Screenshot 2025-06-20 at 17 01 29" src="https://github.com/user-attachments/assets/0e497148-343b-49fc-9330-8c57df756013" />
