### PR TITLE
Safer AddVHTLC method

### DIFF
--- a/internal/infrastructure/db/sqlite/vhtlc_repo.go
+++ b/internal/infrastructure/db/sqlite/vhtlc_repo.go
@@ -29,7 +29,7 @@ func NewVHTLCRepository(db *sql.DB) (domain.VHTLCRepository, error) {
 func (r *vhtlcRepository) Add(ctx context.Context, opts vhtlc.Opts) error {
 	optsParams := toOptParams(opts)
 	if _, err := r.Get(ctx, optsParams.PreimageHash); err == nil {
-		return fmt.Errorf("vHTLC with preimage hash %s alllready exists", optsParams.PreimageHash)
+		return fmt.Errorf("vHTLC with preimage hash %s already exists", optsParams.PreimageHash)
 	}
 
 	if err := r.querier.InsertVHTLC(ctx, optsParams); err != nil {

--- a/internal/test/e2e/e2e_test.go
+++ b/internal/test/e2e/e2e_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"testing"
+	"time"
 
 	"github.com/ArkLabsHQ/fulmine/utils"
 	"github.com/lightningnetwork/lnd/input"
@@ -19,6 +20,8 @@ func TestOnboard(t *testing.T) {
 	txid, err := faucet(onboardAddress, "0.00001")
 	require.NoError(t, err)
 	require.NotEmpty(t, txid)
+
+	time.Sleep(11 * time.Second) // onchain polling interval is 10 seconds
 
 	history, err := getTransactionHistory()
 	require.NoError(t, err)


### PR DESCRIPTION
This PR removes the `Fatal` call when the `Add` method fails. 
It also verifies first if the preimagehash has been used in order to return a meaningful error to the user instead of crashing.

@tiero @altafan please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate entries for vHTLCs by adding a pre-check before saving.
  * Enhanced stability by adjusting error handling to avoid unexpected application termination.
  * Fixed a typo in an error message for improved clarity.
* **Tests**
  * Added a delay in onboarding tests to ensure transaction history reflects the latest onchain state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->