### PR TITLE
Fix Scheduling Of Expired Vtxos

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,6 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
-github.com/a-h/templ v0.3.920 h1:IQjjTu4KGrYreHo/ewzSeS8uefecisPayIIc9VflLSE=
-github.com/a-h/templ v0.3.920/go.mod h1:FFAu4dI//ESmEN7PQkJ7E7QfnSEMdcnu7QrAY8Dn334=
 github.com/a-h/templ v0.3.924 h1:t5gZqTneXqvehpNZsgtnlOscnBboNh9aASBH2MgV/0k=
 github.com/a-h/templ v0.3.924/go.mod h1:FFAu4dI//ESmEN7PQkJ7E7QfnSEMdcnu7QrAY8Dn334=
 github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da h1:KjTM2ks9d14ZYCvmHS9iAKVt9AyzRSqNU1qabPih5BY=

--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -1135,7 +1135,6 @@ func (s *Service) computeNextExpiry(ctx context.Context, data *types.Config) (*t
 	if len(spendableVtxos) > 0 {
 		for _, vtxo := range spendableVtxos[:] {
 			if vtxo.ExpiresAt.Before(time.Now()) {
-				log.Warnf("vtxo %s is already expired, skipping", vtxo.Txid)
 				continue
 			}
 
@@ -1157,7 +1156,6 @@ func (s *Service) computeNextExpiry(ctx context.Context, data *types.Config) (*t
 			// TODO replace by boardingExitDelay https://github.com/ark-network/ark/pull/501
 			boardingExpiry := tx.CreatedAt.Add(time.Duration(data.UnilateralExitDelay.Seconds()*2) * time.Second)
 			if boardingExpiry.Before(time.Now()) {
-				log.Warnf("boarding UTXO %s is already expired, skipping", tx.BoardingTxid)
 				continue
 			}
 


### PR DESCRIPTION
closes #277 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined expiry selection to skip already-expired entries (both spendable and boarding items), ensuring only future expiries are considered.
  * Next-expiry determination now reliably picks the earliest valid expiry, improving accuracy of expiry-related behavior.
  * No public API or signature changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->