### PR TITLE
update to go1.24.6

### DIFF
--- a/.github/workflows/ci.unit.yaml
+++ b/.github/workflows/ci.unit.yaml
@@ -18,7 +18,7 @@ jobs:
       
       - uses: actions/setup-go@v3
         with:
-          go-version: '>=1.24.2'
+          go-version: '>=1.24.6'
           cache: true
       
       # Run linting with the original working configuration

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.23.1
+        go-version: 1.24.6
 
     # Build binaries for all architectures
     - name: Build binaries

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY internal/interface/web .
 RUN rm -rf .parcel-cache && yarn && yarn build
 
 # Build the Go application
-FROM golang:1.24.2 AS go-builder
+FROM golang:1.24.6 AS go-builder
 
 ARG VERSION
 ARG COMMIT

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ⚡️fulmine
 
-[![Go Version](https://img.shields.io/badge/Go-1.23.1-blue.svg)](https://golang.org/doc/go1.23)
+[![Go Version](https://img.shields.io/badge/Go-1.24.6-blue.svg)](https://golang.org/doc/go1.24)
 [![GitHub Release](https://img.shields.io/github/v/release/ArkLabsHQ/fulmine)](https://github.com/ArkLabsHQ/fulmine/releases/latest)
 [![License](https://img.shields.io/github/license/ArkLabsHQ/fulmine)](https://github.com/ArkLabsHQ/fulmine/blob/main/LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/ArkLabsHQ/fulmine)](https://github.com/ArkLabsHQ/fulmine/stargazers)
@@ -238,7 +238,7 @@ For more detailed information about request and response structures, please refe
 
 ## 👨‍💻 Development
 
-To get started with fulmine development you need Go `1.23.1` or higher and Node.js `18.17.1` or higher.
+To get started with fulmine development you need Go `1.24.6` or higher and Node.js `18.17.1` or higher.
 
 ```bash
 git clone https://github.com/ArkLabsHQ/fulmine.git

--- a/arkd.Dockerfile
+++ b/arkd.Dockerfile
@@ -1,5 +1,5 @@
 # First image used to build the sources
-FROM golang:1.23.1 AS builder
+FROM golang:1.24.6 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/arkdwallet.Dockerfile
+++ b/arkdwallet.Dockerfile
@@ -1,5 +1,5 @@
 # First stage: build the ark-wallet-daemon binary
-FROM golang:1.23.1 AS builder
+FROM golang:1.24.6 AS builder
 
 ARG VERSION
 ARG TARGETOS

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ArkLabsHQ/fulmine
 
-go 1.24.2
+go 1.24.6
 
 replace github.com/ArkLabsHQ/fulmine/pkg/vhtlc => ./pkg/vhtlc
 

--- a/pkg/boltz/go.mod
+++ b/pkg/boltz/go.mod
@@ -1,6 +1,6 @@
 module github.com/ArkLabsHQ/fulmine/pkg/boltz
 
-go 1.24.2
+go 1.24.6
 
 require (
 	github.com/gorilla/websocket v1.5.3

--- a/pkg/vhtlc/go.mod
+++ b/pkg/vhtlc/go.mod
@@ -1,8 +1,6 @@
 module github.com/ArkLabsHQ/fulmine/pkg/vhtlc
 
-go 1.23.6
-
-toolchain go1.24.2
+go 1.24.6
 
 require (
 	github.com/arkade-os/arkd/pkg/ark-lib v0.7.1-0.20250724164901-72ea52fed011


### PR DESCRIPTION
fix vulnerability https://www.cve.org/CVERecord/SearchResults?query=CVE-2025-47907

@altafan @Kukks @tiero  please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded Go toolchain to 1.24.6 across the project for consistent builds: CI workflows, release workflow, Docker builder images, and all go.mod files (root, pkg/vhtlc, pkg/boltz). Removed obsolete toolchain directive in pkg/vhtlc. No runtime behavior changes.

* **Documentation**
  * Updated README to reflect Go 1.24.6: badge, linked Go docs, and development requirements text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->