### PR TITLE
Fix Refund Process For PayInvoice And Submarine Swap

### DIFF
--- a/cmd/fulmine/main.go
+++ b/cmd/fulmine/main.go
@@ -104,7 +104,7 @@ func main() {
 		Date:    date,
 	}
 
-	schedulerSvc := scheduler.NewScheduler()
+	schedulerSvc := scheduler.NewScheduler(cfg.EsploraURL)
 
 	appSvc, err := application.NewService(
 		buildInfo, storeCfg, storeSvc, dbSvc, schedulerSvc,

--- a/internal/core/domain/payments.go
+++ b/internal/core/domain/payments.go
@@ -1,0 +1,39 @@
+package domain
+
+import (
+	"context"
+)
+
+type PaymentStatus int
+
+const (
+	PaymentPending PaymentStatus = iota
+	PaymentFailed
+	PaymentSuccess
+)
+
+type PaymentType int
+
+const (
+	Receive PaymentType = iota
+	Pay
+)
+
+type Payment struct {
+	Id        string
+	Amount    uint64
+	Timestamp int64
+
+	Status  PaymentStatus
+	Type    PaymentType
+	Invoice string
+	TxId    string
+}
+
+// PaymentRepository stores the Payment initiated by the wallet
+type PaymentRepository interface {
+	GetAll(ctx context.Context) ([]Payment, error)
+	Get(ctx context.Context, paymentId string) (*Payment, error)
+	Add(ctx context.Context, payment Payment) error
+	Close()
+}

--- a/internal/core/ports/repo_manager.go
+++ b/internal/core/ports/repo_manager.go
@@ -7,6 +7,7 @@ type RepoManager interface {
 	VHTLC() domain.VHTLCRepository
 	VtxoRollover() domain.VtxoRolloverRepository
 	Swap() domain.SwapRepository
+	Payment() domain.PaymentRepository
 	SubscribedScript() domain.SubscribedScriptRepository
 	Close()
 }

--- a/internal/core/ports/scheduler.go
+++ b/internal/core/ports/scheduler.go
@@ -8,5 +8,7 @@ type SchedulerService interface {
 	Start()
 	Stop()
 	ScheduleNextSettlement(at time.Time, settleFunc func()) error
+	ScheduleRefundAtTime(at time.Time, refundFunc func()) error
+	ScheduleRefundAtHeight(target uint32, refund func()) error
 	WhenNextSettlement() time.Time
 }

--- a/internal/infrastructure/db/badger/payment_repo.go
+++ b/internal/infrastructure/db/badger/payment_repo.go
@@ -1,0 +1,69 @@
+package badgerdb
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"github.com/ArkLabsHQ/fulmine/internal/core/domain"
+	"github.com/dgraph-io/badger/v4"
+	"github.com/timshannon/badgerhold/v4"
+)
+
+const (
+	paymentDir = "payment"
+)
+
+type paymentRepository struct {
+	store *badgerhold.Store
+}
+
+func NewPaymentRepository(baseDir string, logger badger.Logger) (domain.PaymentRepository, error) {
+	var dir string
+	if len(baseDir) > 0 {
+		dir = filepath.Join(baseDir, paymentDir)
+	}
+	store, err := createDB(dir, logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open payment store: %s", err)
+	}
+	return &paymentRepository{store}, nil
+}
+
+func (r *paymentRepository) GetAll(ctx context.Context) ([]domain.Payment, error) {
+	var payments []domain.Payment
+	err := r.store.Find(&payments, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get all swaps: %w", err)
+	}
+
+	return payments, nil
+}
+
+func (r *paymentRepository) Get(ctx context.Context, paymentId string) (*domain.Payment, error) {
+	var payment domain.Payment
+	err := r.store.Get(paymentId, &payment)
+	if errors.Is(err, badgerhold.ErrNotFound) {
+		return nil, fmt.Errorf("swap %s not found", paymentId)
+	}
+
+	return &payment, nil
+}
+
+// Add stores a new Swap in the database
+func (r *paymentRepository) Add(ctx context.Context, payment domain.Payment) error {
+
+	if err := r.store.Insert(payment.Id, payment); err != nil {
+		if errors.Is(err, badgerhold.ErrKeyExists) {
+			return fmt.Errorf("payment %s already exists", payment.Id)
+		}
+		return err
+	}
+	return nil
+}
+
+func (s *paymentRepository) Close() {
+	// nolint:all
+	s.store.Close()
+}

--- a/internal/infrastructure/db/service.go
+++ b/internal/infrastructure/db/service.go
@@ -38,6 +38,7 @@ type service struct {
 	vhtlcRepo            domain.VHTLCRepository
 	vtxoRolloverRepo     domain.VtxoRolloverRepository
 	swapRepo             domain.SwapRepository
+	paymentRepo          domain.PaymentRepository
 	subscribedScriptRepo domain.SubscribedScriptRepository
 }
 
@@ -47,6 +48,7 @@ func NewService(config ServiceConfig) (ports.RepoManager, error) {
 		vhtlcRepo            domain.VHTLCRepository
 		vtxoRolloverRepo     domain.VtxoRolloverRepository
 		swapRepo             domain.SwapRepository
+		paymentRepo          domain.PaymentRepository
 		subscribedScriptRepo domain.SubscribedScriptRepository
 		err                  error
 	)
@@ -83,6 +85,12 @@ func NewService(config ServiceConfig) (ports.RepoManager, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to open swap db: %s", err)
 		}
+
+		paymentRepo, err = badgerdb.NewPaymentRepository(baseDir, logger)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open payment db: %s", err)
+		}
+
 		subscribedScriptRepo, err = badgerdb.NewSubscribedScriptRepository(baseDir, logger)
 		if err != nil {
 			return nil, fmt.Errorf("failed to open subscribed script db: %s", err)
@@ -137,6 +145,11 @@ func NewService(config ServiceConfig) (ports.RepoManager, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to open swap db: %s", err)
 		}
+		paymentRepo, err = sqlitedb.NewPaymentRepository(db)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open payment db: %s", err)
+		}
+
 		subscribedScriptRepo, err = sqlitedb.NewSubscribedScriptRepository(db)
 		if err != nil {
 			return nil, fmt.Errorf("failed to open subscribed script db: %s", err)
@@ -151,6 +164,7 @@ func NewService(config ServiceConfig) (ports.RepoManager, error) {
 		vhtlcRepo:            vhtlcRepo,
 		vtxoRolloverRepo:     vtxoRolloverRepo,
 		swapRepo:             swapRepo,
+		paymentRepo:          paymentRepo,
 		subscribedScriptRepo: subscribedScriptRepo,
 	}, nil
 }
@@ -171,6 +185,10 @@ func (s *service) Swap() domain.SwapRepository {
 	return s.swapRepo
 }
 
+func (s *service) Payment() domain.PaymentRepository {
+	return s.paymentRepo
+}
+
 func (s *service) SubscribedScript() domain.SubscribedScriptRepository {
 	return s.subscribedScriptRepo
 }
@@ -180,5 +198,6 @@ func (s *service) Close() {
 	s.vhtlcRepo.Close()
 	s.vtxoRolloverRepo.Close()
 	s.swapRepo.Close()
+	s.paymentRepo.Close()
 	s.subscribedScriptRepo.Close()
 }

--- a/internal/infrastructure/db/sqlite/migration/20250813151053_add_payment_table.down.sql
+++ b/internal/infrastructure/db/sqlite/migration/20250813151053_add_payment_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS payment;

--- a/internal/infrastructure/db/sqlite/migration/20250813151053_add_payment_table.up.sql
+++ b/internal/infrastructure/db/sqlite/migration/20250813151053_add_payment_table.up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS payment (
+    id TEXT PRIMARY KEY,
+    amount INTEGER NOT NULL,
+    timestamp INTEGER NOT NULL,
+    payment_type INTEGER NOT NULL CHECK(payment_type IN(0,1)),
+    status INTEGER NOT NULL CHECK(status IN(0,1,2)),
+    invoice TEXT NOT NULL,
+    tx_id TEXT NOT NULL
+);

--- a/internal/infrastructure/db/sqlite/payment_repo.go
+++ b/internal/infrastructure/db/sqlite/payment_repo.go
@@ -1,0 +1,84 @@
+package sqlitedb
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/ArkLabsHQ/fulmine/internal/core/domain"
+	"github.com/ArkLabsHQ/fulmine/internal/infrastructure/db/sqlite/sqlc/queries"
+)
+
+type paymentRepository struct {
+	db      *sql.DB
+	querier *queries.Queries
+}
+
+func NewPaymentRepository(db *sql.DB) (domain.PaymentRepository, error) {
+	if db == nil {
+		return nil, fmt.Errorf("cannot open vtxo rollover repository: db is nil")
+	}
+
+	return &paymentRepository{
+		db:      db,
+		querier: queries.New(db),
+	}, nil
+}
+
+func (r *paymentRepository) Add(ctx context.Context, payment domain.Payment) error {
+	return r.querier.CreatePayment(ctx, queries.CreatePaymentParams{
+		ID:          payment.Id,
+		Amount:      int64(payment.Amount),
+		Timestamp:   payment.Timestamp,
+		Status:      int64(payment.Status),
+		PaymentType: int64(payment.Type),
+		Invoice:     payment.Invoice,
+		TxID:        payment.TxId,
+	})
+}
+
+func (r *paymentRepository) Get(ctx context.Context, paymentId string) (*domain.Payment, error) {
+	row, err := r.querier.GetPayment(ctx, paymentId)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("swap %s not found", paymentId)
+		}
+		return nil, err
+	}
+
+	return toPayment(row)
+}
+
+func (r *paymentRepository) GetAll(ctx context.Context) ([]domain.Payment, error) {
+	rows, err := r.querier.ListPayments(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var results []domain.Payment
+	for _, row := range rows {
+		payment, err := toPayment(row)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, *payment)
+	}
+	return results, nil
+}
+
+func (r *paymentRepository) Close() {
+	// nolint
+	r.db.Close()
+}
+
+func toPayment(payment queries.Payment) (*domain.Payment, error) {
+	return &domain.Payment{
+		Id:        payment.ID,
+		Amount:    uint64(payment.Amount),
+		Timestamp: payment.Timestamp,
+		Status:    domain.PaymentStatus(payment.Status),
+		Invoice:   payment.Invoice,
+		TxId:      payment.TxID,
+		Type:      domain.PaymentType(payment.PaymentType),
+	}, nil
+}

--- a/internal/infrastructure/db/sqlite/sqlc/queries/models.go
+++ b/internal/infrastructure/db/sqlite/sqlc/queries/models.go
@@ -8,6 +8,16 @@ import (
 	"database/sql"
 )
 
+type Payment struct {
+	ID          string
+	Amount      int64
+	Timestamp   int64
+	PaymentType int64
+	Status      int64
+	Invoice     string
+	TxID        string
+}
+
 type Setting struct {
 	ID          int64
 	ApiRoot     string

--- a/internal/infrastructure/db/sqlite/sqlc/query.sql
+++ b/internal/infrastructure/db/sqlite/sqlc/query.sql
@@ -82,3 +82,20 @@ SELECT * FROM subscribed_script;
 
 -- name: DeleteSubscribedScript :exec
 DELETE FROM subscribed_script WHERE script = ?;
+
+-- Payment queries
+-- name: CreatePayment :exec
+INSERT INTO payment (id, amount, timestamp, payment_type, status, invoice, tx_id)
+VALUES (?, ?, ?, ?, ?, ?, ?);
+
+-- name: GetPayment :one
+SELECT * FROM payment WHERE id = ? LIMIT 1;
+
+-- name: ListPayments :many
+SELECT * FROM payment ORDER BY timestamp DESC;
+
+-- (optional) name: UpdatePaymentStatus :exec
+UPDATE payment SET status = ? WHERE id = ?;
+
+-- (optional) name: ListPaymentsByType :many
+SELECT * FROM payment WHERE payment_type = ? ORDER BY timestamp DESC;

--- a/internal/infrastructure/esplora/service.go
+++ b/internal/infrastructure/esplora/service.go
@@ -1,0 +1,56 @@
+package esplora
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Service interface {
+	GetBlockHeight(ctx context.Context) (int64, error)
+}
+
+type service struct {
+	baseUrl string
+}
+
+func NewService(url string) *service {
+	return &service{
+		baseUrl: url,
+	}
+}
+
+func (s *service) GetBlockHeight(ctx context.Context) (int64, error) {
+	url := strings.TrimRight(s.baseUrl, "/") + "/blocks/tip/height"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return 0, err
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("get height: %w", err)
+	}
+	defer resp.Body.Close()
+
+	b, err := io.ReadAll(io.LimitReader(resp.Body, 64))
+	if err != nil {
+		return 0, fmt.Errorf("read body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, strings.TrimSpace(string(b)))
+	}
+
+	n, err := strconv.ParseInt(strings.TrimSpace(string(b)), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse height: %w", err)
+	}
+	return n, nil
+}

--- a/internal/infrastructure/scheduler/gocron/service.go
+++ b/internal/infrastructure/scheduler/gocron/service.go
@@ -1,31 +1,138 @@
 package scheduler
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/ArkLabsHQ/fulmine/internal/core/ports"
+	"github.com/ArkLabsHQ/fulmine/internal/infrastructure/esplora"
 	"github.com/go-co-op/gocron"
 )
 
-type service struct {
-	scheduler *gocron.Scheduler
-	job       *gocron.Job
-	mu        *sync.Mutex
+type heightTask struct {
+	target uint32
+	fn     func()
 }
 
-func NewScheduler() ports.SchedulerService {
+type service struct {
+	scheduler      *gocron.Scheduler
+	esploraService esplora.Service
+	job            *gocron.Job
+	mu             *sync.Mutex
+	blockCancel    context.CancelFunc
+	tasks          []*heightTask
+}
+
+func NewScheduler(esplorerUrl string) ports.SchedulerService {
 	svc := gocron.NewScheduler(time.UTC)
-	return &service{svc, nil, &sync.Mutex{}}
+	esplorerService := esplora.NewService(esplorerUrl)
+	return &service{svc, esplorerService, nil, &sync.Mutex{}, nil, nil}
 }
 
 func (s *service) Start() {
 	s.scheduler.StartAsync()
+
+	pollInterval := 5 * time.Second
+
+	s.mu.Lock()
+	if s.blockCancel != nil {
+		s.mu.Unlock()
+		return
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	s.blockCancel = cancel
+	s.mu.Unlock()
+
+	go func() {
+		t := time.NewTicker(pollInterval)
+		defer t.Stop()
+		for {
+			callCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+			h, err := s.esploraService.GetBlockHeight(callCtx)
+			cancel()
+
+			if err == nil {
+				s.mu.Lock()
+				keep := s.tasks[:0]
+				for _, tsk := range s.tasks {
+					if uint32(h) >= tsk.target {
+						go tsk.fn()
+						continue
+					}
+					keep = append(keep, tsk)
+				}
+				s.tasks = keep
+				s.mu.Unlock()
+			}
+
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+			}
+		}
+	}()
 }
 
 func (s *service) Stop() {
 	s.scheduler.Stop()
+
+	s.mu.Lock()
+	if s.blockCancel != nil {
+		s.blockCancel()
+		s.blockCancel = nil
+	}
+	s.mu.Unlock()
+}
+
+func (s *service) ScheduleRefundAtHeight(target uint32, refund func()) error {
+	if target <= 0 {
+		return fmt.Errorf("invalid height: %d", target)
+	}
+	tsk := &heightTask{target: target, fn: refund}
+	s.mu.Lock()
+	s.tasks = append(s.tasks, tsk)
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *service) ScheduleRefundAtTime(at time.Time, refundFunc func()) error {
+	if at.IsZero() {
+		return fmt.Errorf("invalid schedule time")
+	}
+
+	delay := time.Until(at)
+	if delay < 0 {
+		return fmt.Errorf("cannot schedule task in the past")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.scheduler.Remove(s.job)
+	s.job = nil
+
+	if delay == 0 {
+		refundFunc()
+		return nil
+	}
+
+	job, err := s.scheduler.Every(delay).WaitForSchedule().LimitRunsTo(1).Do(func() {
+		refundFunc()
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		s.scheduler.Remove(s.job)
+		s.job = nil
+	})
+	if err != nil {
+		return err
+	}
+
+	s.job = job
+
+	return err
 }
 
 // ScheduleNextSettlement schedules a Settle() to run in the best market hour

--- a/internal/interface/web/templates/pages/send.templ
+++ b/internal/interface/web/templates/pages/send.templ
@@ -163,3 +163,19 @@ templ SendSuccessContent(address, amount, txid, explorerUrl string) {
 		}
 	</div>
 }
+
+templ SendPendingContent(address, amount string) {
+	<div class="p-3 flex flex-col justify-between rounded-lg h-screen md:h-auto md:bg-desktopbg">
+		<div class="flex flex-col items-center">
+			@components.Header("Sending")
+			<div class="mt-6 h-16 w-16 rounded-full border-4 border-white/20 border-t-white animate-spin"></div>
+			<p class="mt-8">Invoice Payment Pending…</p>
+			<p class="mt-8 text-3xl cryptoAmount" sats={amount}>{amount} SATS</p>
+			<div class="flex mt-8 w-64 gap-2 items-center">
+				<p class="text-white/50">to</p>
+				<p class="overflow-hidden text-ellipsis whitespace-nowrap">{address}</p>
+				<p class="text-white/50">@components.CopyWidget(address)</p>
+			</div>
+		</div>
+	</div>
+}

--- a/internal/interface/web/templates/pages/send_templ.go
+++ b/internal/interface/web/templates/pages/send_templ.go
@@ -384,4 +384,88 @@ func SendSuccessContent(address, amount, txid, explorerUrl string) templ.Compone
 	})
 }
 
+func SendPendingContent(address, amount string) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var15 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var15 == nil {
+			templ_7745c5c3_Var15 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "<div class=\"p-3 flex flex-col justify-between rounded-lg h-screen md:h-auto md:bg-desktopbg\"><div class=\"flex flex-col items-center\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = components.Header("Sending").Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<div class=\"mt-6 h-16 w-16 rounded-full border-4 border-white/20 border-t-white animate-spin\"></div><p class=\"mt-8\">Invoice Payment Pending…</p><p class=\"mt-8 text-3xl cryptoAmount\" sats=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var16 string
+		templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(amount)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/send.templ`, Line: 173, Col: 53}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var17 string
+		templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(amount)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/send.templ`, Line: 173, Col: 62}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, " SATS</p><div class=\"flex mt-8 w-64 gap-2 items-center\"><p class=\"text-white/50\">to</p><p class=\"overflow-hidden text-ellipsis whitespace-nowrap\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var18 string
+		templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(address)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/send.templ`, Line: 176, Col: 71}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "</p><p class=\"text-white/50\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = components.CopyWidget(address).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "</p></div></div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
 var _ = templruntime.GeneratedTemplate

--- a/utils/invoice.go
+++ b/utils/invoice.go
@@ -7,19 +7,19 @@ import (
 	decodepay "github.com/nbd-wtf/ln-decodepay"
 )
 
-func DecodeInvoice(invoice string) (uint64, []byte, error) {
+func DecodeInvoice(invoice string) (uint64, []byte, *decodepay.Bolt11, error) {
 	bolt11, err := decodepay.Decodepay(invoice)
 	if err != nil {
-		return 0, nil, err
+		return 0, nil, nil, err
 	}
 
 	amount := uint64(bolt11.MSatoshi / 1000)
 	preimageHash, err := hex.DecodeString(bolt11.PaymentHash)
 	if err != nil {
-		return 0, nil, err
+		return 0, nil, nil, err
 	}
 
-	return amount, input.Ripemd160H(preimageHash), nil
+	return amount, input.Ripemd160H(preimageHash), &bolt11, nil
 }
 
 func SatsFromInvoice(invoice string) int {


### PR DESCRIPTION
## Objective

The refund process for `PayInvoice` and `SubmarineSwap` is currently broken. This is because refunds need to wait for a specific block height before being processed, a feature that is not yet implemented. The proposed solution is to poll for the current Bitcoin block height and, once the refund becomes eligible, initiate the refund process.

### Note: This is a draft, necessary to finalize the UI and process design.

@altafan Kindly review.

## Tasks
- [x] Refund process for PayInvoice

