### PR TITLE
Use ln instructions from regtest

### DIFF
--- a/internal/interface/web/templates/modals/ln_connect.templ
+++ b/internal/interface/web/templates/modals/ln_connect.templ
@@ -31,7 +31,7 @@ templ lnConnectSection(number, title, text string) {
 templ LnConnectCodeSample() {
   <div class="flex flex-col gap-2">
     <p class="text-sm text-white/50">SAMPLE CODE</p>
-    @components.CodeSample("echo 'lndconnect://example.com?cert='\"`grep -v 'CERTIFICATE' tls.cert | tr -d '=' | tr '/+' '_-'`\"'&macaroon='\"`base64 admin.macaroon | tr -d '=' | tr '/+' '_-'`\" | tr -d '\n' | qrencode -o /tmp/out.png")
+    @components.CodeSample("docker exec -i boltz-lnd bash -c 'echo -n \"lndconnect://boltz-lnd:10009?cert=$(grep -v CERTIFICATE /root/.lnd/tls.cert | tr -d = | tr \"/+\" \"_-\")&macaroon=$(base64 /root/.lnd/data/chain/bitcoin/regtest/admin.macaroon | tr -d = | tr \"/+\" \"_-\")\"'")
   </div>
 }
 


### PR DESCRIPTION
Update example code in lightning "How to connect?" to match code used in regtest

@Kukks please review

closes #291 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Lightning Connect modal’s code sample to a Docker-based command that outputs the lndconnect URL directly.
  * Uses in-container cert/macaroon paths and boltz-lnd:10009 (regtest) for accuracy with containerized setups.
  * Removes QR generation and temp file output, reducing reliance on external tools.
  * Simplifies copy-paste instructions and improves reliability for users running LND inside Docker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->