### PR TITLE
Fix spelling in proto files

### DIFF
--- a/api-spec/openapi/swagger/fulmine/v1/notification.swagger.json
+++ b/api-spec/openapi/swagger/fulmine/v1/notification.swagger.json
@@ -198,7 +198,7 @@
             "type": "object",
             "$ref": "#/definitions/v1WebhookInfo"
           },
-          "description": "The list of info about the webhooks regitered for an action."
+          "description": "The list of info about the webhooks registered for an action."
         }
       }
     },

--- a/api-spec/openapi/swagger/fulmine/v1/service.swagger.json
+++ b/api-spec/openapi/swagger/fulmine/v1/service.swagger.json
@@ -882,7 +882,7 @@
       "properties": {
         "network": {
           "$ref": "#/definitions/GetInfoResponseNetwork",
-          "description": "The bitcoin network on which Fulmine is runnig."
+          "description": "The bitcoin network on which Fulmine is running."
         },
         "addrPrefix": {
           "type": "string",

--- a/api-spec/openapi/swagger/fulmine/v1/wallet.swagger.json
+++ b/api-spec/openapi/swagger/fulmine/v1/wallet.swagger.json
@@ -320,7 +320,7 @@
       "properties": {
         "currentPassword": {
           "type": "string",
-          "description": "The current password used to encrypt the walley."
+          "description": "The current password used to encrypt the wallet."
         },
         "newPassword": {
           "type": "string",

--- a/api-spec/protobuf/fulmine/v1/notification.proto
+++ b/api-spec/protobuf/fulmine/v1/notification.proto
@@ -85,7 +85,7 @@ message AddWebhookRequest {
   string endpoint = 1;
   // The event type for which the webhook should be registered.
   WebhookEventType event_type = 2;
-  // The secret to use for signign a JWT token for an authenticated request
+  // The secret to use for signing a JWT token for an authenticated request
   // to the external service.
   string secret = 3;
 }
@@ -105,7 +105,7 @@ message ListWebhooksRequest {
   WebhookEventType event_type = 1;
 }
 message ListWebhooksResponse {
-  // The list of info about the webhooks regitered for an action.
+  // The list of info about the webhooks registered for an action.
   repeated WebhookInfo webhook_info = 1;
 }
 

--- a/api-spec/protobuf/fulmine/v1/service.proto
+++ b/api-spec/protobuf/fulmine/v1/service.proto
@@ -172,7 +172,7 @@ message GetInfoResponse {
     NETWORK_TESTNET = 2;
     NETWORK_REGTEST = 3;
   }
-  // The bitcoin network on which Fulmine is runnig.
+  // The bitcoin network on which Fulmine is running.
   Network network = 1;
   // The ark address prefix (ark | tark).
   string addr_prefix = 2;

--- a/api-spec/protobuf/fulmine/v1/wallet.proto
+++ b/api-spec/protobuf/fulmine/v1/wallet.proto
@@ -109,7 +109,7 @@ message LockRequest{
 message LockResponse{}
 
 message ChangePasswordRequest{
-  // The current password used to encrypt the walley.
+  // The current password used to encrypt the wallet.
   string current_password = 1;
 
   // The new password replacing the current one.

--- a/api-spec/protobuf/gen/go/fulmine/v1/notification.pb.go
+++ b/api-spec/protobuf/gen/go/fulmine/v1/notification.pb.go
@@ -394,7 +394,7 @@ type AddWebhookRequest struct {
 	Endpoint string `protobuf:"bytes,1,opt,name=endpoint,proto3" json:"endpoint,omitempty"`
 	// The event type for which the webhook should be registered.
 	EventType WebhookEventType `protobuf:"varint,2,opt,name=event_type,json=eventType,proto3,enum=fulmine.v1.WebhookEventType" json:"event_type,omitempty"`
-	// The secret to use for signign a JWT token for an authenticated request
+	// The secret to use for signing a JWT token for an authenticated request
 	// to the external service.
 	Secret string `protobuf:"bytes,3,opt,name=secret,proto3" json:"secret,omitempty"`
 }
@@ -639,7 +639,7 @@ type ListWebhooksResponse struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// The list of info about the webhooks regitered for an action.
+	// The list of info about the webhooks registered for an action.
 	WebhookInfo []*WebhookInfo `protobuf:"bytes,1,rep,name=webhook_info,json=webhookInfo,proto3" json:"webhook_info,omitempty"`
 }
 

--- a/api-spec/protobuf/gen/go/fulmine/v1/service.pb.go
+++ b/api-spec/protobuf/gen/go/fulmine/v1/service.pb.go
@@ -343,7 +343,7 @@ type GetInfoResponse struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// The bitcoin network on which Fulmine is runnig.
+	// The bitcoin network on which Fulmine is running.
 	Network GetInfoResponse_Network `protobuf:"varint,1,opt,name=network,proto3,enum=fulmine.v1.GetInfoResponse_Network" json:"network,omitempty"`
 	// The ark address prefix (ark | tark).
 	AddrPrefix string `protobuf:"bytes,2,opt,name=addr_prefix,json=addrPrefix,proto3" json:"addr_prefix,omitempty"`

--- a/api-spec/protobuf/gen/go/fulmine/v1/wallet.pb.go
+++ b/api-spec/protobuf/gen/go/fulmine/v1/wallet.pb.go
@@ -399,7 +399,7 @@ type ChangePasswordRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// The current password used to encrypt the walley.
+	// The current password used to encrypt the wallet.
 	CurrentPassword string `protobuf:"bytes,1,opt,name=current_password,json=currentPassword,proto3" json:"current_password,omitempty"`
 	// The new password replacing the current one.
 	NewPassword string `protobuf:"bytes,2,opt,name=new_password,json=newPassword,proto3" json:"new_password,omitempty"`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed multiple spelling errors in API descriptions across notification, service, and wallet endpoints (e.g., “registered,” “running,” “wallet”).
  * Improved clarity of field descriptions for webhook info, network details, and password change requests.
  * Aligned OpenAPI and protobuf comments for consistency.
  * No changes to request/response structures or behavior; these updates are doc-only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->