### PR TITLE
Scheduler: fix boarding utxo delay

### DIFF
--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -1244,8 +1244,8 @@ func (s *Service) computeNextExpiry(ctx context.Context, data *types.Config) (*t
 	// check for unsettled boarding UTXOs
 	for _, tx := range txs {
 		if len(tx.BoardingTxid) > 0 && !tx.Settled {
-			// TODO replace by boardingExitDelay https://github.com/ark-network/ark/pull/501
-			boardingExpiry := tx.CreatedAt.Add(time.Duration(data.UnilateralExitDelay.Seconds()*2) * time.Second)
+			boardingDelay := time.Duration(data.BoardingExitDelay.Seconds()) * time.Second
+			boardingExpiry := tx.CreatedAt.Add(boardingDelay)
 			if boardingExpiry.Before(time.Now()) {
 				continue
 			}


### PR DESCRIPTION
fix an old TODO in `computeNextExpiry` func

@altafan please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Updated boarding expiry calculation to use a configurable delay mechanism instead of a hardcoded value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->