### PR TITLE
Handle closed subscription channel in start method

### DIFF
--- a/internal/core/application/subscription.go
+++ b/internal/core/application/subscription.go
@@ -232,7 +232,7 @@ func (h *subscriptionHandler) start() error {
 					return
 				case event, ok := <-subscriptionChannel:
 					if !ok {
-						log.Warnf("subscription channel closed, retrying...")
+						onError(fmt.Errorf("subscription channel closed"))
 						stopped = true
 						continue
 					}

--- a/internal/core/application/subscription.go
+++ b/internal/core/application/subscription.go
@@ -230,7 +230,13 @@ func (h *subscriptionHandler) start() error {
 				select {
 				case <-ctx.Done():
 					return
-				case event := <-subscriptionChannel:
+				case event, ok := <-subscriptionChannel:
+					if !ok {
+						log.Warnf("subscription channel closed, retrying...")
+						stopped = true
+						continue
+					}
+
 					if event.Err != nil {
 						onError(event.Err)
 						stopped = true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription loop stability by properly detecting closed subscription channels: now logs a warning when a channel closes, marks the loop as stopped, and automatically retries to re-establish processing so subscriptions recover gracefully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->