### PR TITLE
Add e2e test for cooperative refund of underfunded submarine swap

### DIFF
--- a/.github/workflows/ci.integration.yaml
+++ b/.github/workflows/ci.integration.yaml
@@ -32,3 +32,12 @@ jobs:
 
       - name: Run integration tests
         run: make integrationtest
+
+      - name: Docker logs
+        if: failure()
+        continue-on-error: true
+        run: |
+          docker image ls -a
+          docker ps -a
+          docker compose -f test.docker-compose.yml ps
+          docker compose -f test.docker-compose.yml logs --no-color --timestamps boltz fulmine boltz-fulmine mock-boltz

--- a/internal/test/e2e/main_test.go
+++ b/internal/test/e2e/main_test.go
@@ -103,8 +103,11 @@ func refillFulmine(ctx context.Context, url string) error {
 		}
 	}
 
-	time.Sleep(5 * time.Second)
-	_, err = f.Settle(ctx, &pb.SettleRequest{})
-	time.Sleep(5 * time.Second)
-	return err
+	return waitForSettle(ctx, func(ctx context.Context) error {
+		_, err := f.Settle(ctx, &pb.SettleRequest{})
+		if err != nil {
+			return err
+		}
+		return nil
+	})
 }

--- a/internal/test/e2e/swap_test.go
+++ b/internal/test/e2e/swap_test.go
@@ -1,11 +1,19 @@
 package e2e_test
 
 import (
+	"encoding/hex"
 	"sync"
 	"testing"
 	"time"
 
 	pb "github.com/ArkLabsHQ/fulmine/api-spec/protobuf/gen/go/fulmine/v1"
+	"github.com/ArkLabsHQ/fulmine/pkg/boltz"
+	"github.com/ArkLabsHQ/fulmine/pkg/swap"
+	"github.com/ArkLabsHQ/fulmine/pkg/vhtlc"
+	arklib "github.com/arkade-os/arkd/pkg/ark-lib"
+	clientTypes "github.com/arkade-os/arkd/pkg/client-lib/types"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/lightningnetwork/lnd/input"
 	"github.com/stretchr/testify/require"
 )
 
@@ -358,6 +366,82 @@ func (e *errs) add(err error) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.errs = append(e.errs, err)
+}
+
+func TestSubmarineSwapUnderfundedCooperativeRefund(t *testing.T) {
+	ctx := t.Context()
+
+	arkClient, arkPubKey, _ := setupArkSDKwithPublicKey(t)
+	faucetOffchain(t, arkClient, 0.001)
+
+	cfg, err := arkClient.GetConfigData(ctx)
+	require.NoError(t, err)
+
+	handlerKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	boltzApi := &boltz.Api{URL: "http://localhost:9001", WSURL: "ws://localhost:9004"}
+
+	invoice, rHash, err := lndAddInvoice(ctx, 5000)
+	require.NoError(t, err)
+	require.NotEmpty(t, invoice)
+
+	preimageHash := input.Ripemd160H(mustDecodeHex(t, rHash))
+
+	createResp, err := boltzApi.CreateSwap(boltz.CreateSwapRequest{
+		From:            boltz.CurrencyArk,
+		To:              boltz.CurrencyBtc,
+		Invoice:         invoice,
+		RefundPublicKey: hex.EncodeToString(arkPubKey.SerializeCompressed()),
+		PaymentTimeout:  120,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, createResp.Address)
+	require.Greater(t, createResp.ExpectedAmount, uint64(100))
+
+	receiverPubBytes, err := hex.DecodeString(createResp.ClaimPublicKey)
+	require.NoError(t, err)
+	receiverPub, err := btcec.ParsePubKey(receiverPubBytes)
+	require.NoError(t, err)
+
+	opts := vhtlc.Opts{
+		Sender:                               arkPubKey,
+		Receiver:                             receiverPub,
+		Server:                               cfg.SignerPubKey,
+		PreimageHash:                         preimageHash,
+		RefundLocktime:                       arklib.AbsoluteLocktime(createResp.TimeoutBlockHeights.RefundLocktime),
+		UnilateralClaimDelay:                 boltzLocktime(createResp.TimeoutBlockHeights.UnilateralClaim),
+		UnilateralRefundDelay:                boltzLocktime(createResp.TimeoutBlockHeights.UnilateralRefund),
+		UnilateralRefundWithoutReceiverDelay: boltzLocktime(createResp.TimeoutBlockHeights.UnilateralRefundWithoutReceiver),
+	}
+	script, err := vhtlc.NewVHTLCScriptFromOpts(opts)
+	require.NoError(t, err)
+	addr, err := script.Address(cfg.Network.Addr)
+	require.NoError(t, err)
+	require.Equal(t, createResp.Address, addr, "locally derived VHTLC address must match Boltz's")
+
+	short := createResp.ExpectedAmount - 100
+	_, err = arkClient.SendOffChain(ctx, []clientTypes.Receiver{
+		{To: createResp.Address, Amount: short},
+	})
+	require.NoError(t, err)
+
+	// Give Boltz time to observe the underfunded lockup tx and mark the swap
+	// as failed before we ask it to co-sign the refund.
+	time.Sleep(5 * time.Second)
+
+	handler, err := swap.NewSwapHandler(arkClient, boltzApi, "", handlerKey, 120)
+	require.NoError(t, err)
+
+	_, err = handler.RefundSwap(ctx, swap.SwapTypeSubmarine, createResp.Id, true, opts, nil)
+	require.NoError(t, err, "cooperative refund of an underfunded submarine swap should succeed")
+}
+
+func boltzLocktime(value uint32) arklib.RelativeLocktime {
+	if value >= 512 {
+		return arklib.RelativeLocktime{Type: arklib.LocktimeTypeSecond, Value: value}
+	}
+	return arklib.RelativeLocktime{Type: arklib.LocktimeTypeBlock, Value: value}
 }
 
 // TODO: add tests for increase inbound/outbound

--- a/internal/test/e2e/utils_test.go
+++ b/internal/test/e2e/utils_test.go
@@ -827,3 +827,35 @@ func verifyInputSignatures(
 
 	return nil
 }
+
+func faucetAndSettle(t *testing.T, ctx context.Context, c arksdk.ArkClient, address string, amount float64){
+	t.Helper()
+
+	err := faucet(ctx, strings.TrimSpace(address), amount)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		_, err := c.Settle(ctx)
+		return err == nil
+	}, 30*time.Second, 1*time.Second, "settle never succeeded")
+	return
+}
+
+// utils_test.go — for non-test setup (used in refillFulmine / TestMain)
+func waitForSettle(ctx context.Context, settle func(context.Context) error) error {
+	deadline := time.Now().Add(30 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		if err := settle(ctx); err == nil {
+			return nil
+		} else {
+			lastErr = err
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(1 * time.Second):
+		}
+	}
+	return fmt.Errorf("settle never succeeded within 30s: last err: %w", lastErr)
+}

--- a/internal/test/e2e/vhtlc_test.go
+++ b/internal/test/e2e/vhtlc_test.go
@@ -691,13 +691,7 @@ func TestSettleVHTLCByDelegateRefund(t *testing.T) {
 	_, offchain, boarding, _, err := senderArkClient.GetAddresses(ctx)
 	require.NoError(t, err)
 
-	err = faucet(ctx, strings.TrimSpace(boarding[0]), 0.001)
-	require.NoError(t, err)
-
-	time.Sleep(5 * time.Second)
-
-	_, err = senderArkClient.Settle(ctx)
-	require.NoError(t, err)
+	faucetAndSettle(t, ctx, senderArkClient, boarding[0], 0.001)
 
 	preimage := make([]byte, 32)
 	_, err = rand.Read(preimage)
@@ -844,13 +838,7 @@ func TestSettleVHTLCByDelegateRefundWithOutpoint(t *testing.T) {
 	_, offchain, boarding, _, err := senderArkClient.GetAddresses(ctx)
 	require.NoError(t, err)
 
-	err = faucet(ctx, strings.TrimSpace(boarding[0]), 0.001)
-	require.NoError(t, err)
-
-	time.Sleep(5 * time.Second)
-
-	_, err = senderArkClient.Settle(ctx)
-	require.NoError(t, err)
+	faucetAndSettle(t, ctx, senderArkClient, strings.TrimSpace(boarding[0]), 0.001)
 
 	preimage := make([]byte, 32)
 	_, err = rand.Read(preimage)
@@ -1178,11 +1166,7 @@ func TestClaimVHTLCPendingFinalization(t *testing.T) {
 	_, _, boarding, _, err := arkadeWallet.GetAddresses(ctx)
 	require.NoError(t, err)
 
-	err = faucet(ctx, strings.TrimSpace(boarding[0]), 0.001)
-	require.NoError(t, err)
-	time.Sleep(5 * time.Second)
-	_, err = arkadeWallet.Settle(ctx)
-	require.NoError(t, err)
+	faucetAndSettle(t, ctx, arkadeWallet, boarding[0], 0.001)
 
 	info, err := f.GetInfo(ctx, &pb.GetInfoRequest{})
 	require.NoError(t, err)
@@ -1250,11 +1234,7 @@ func TestRefundVHTLCPendingFinalization(t *testing.T) {
 	_, _, boarding, _, err := arkClient.GetAddresses(ctx)
 	require.NoError(t, err)
 
-	err = faucet(ctx, strings.TrimSpace(boarding[0]), 0.001)
-	require.NoError(t, err)
-	time.Sleep(5 * time.Second)
-	_, err = arkClient.Settle(ctx)
-	require.NoError(t, err)
+	faucetAndSettle(t, ctx, arkClient, boarding[0], 0.001)
 
 	preimage := make([]byte, 32)
 	_, err = rand.Read(preimage)

--- a/pkg/swap/chainswap_btc_ark_handler.go
+++ b/pkg/swap/chainswap_btc_ark_handler.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ArkLabsHQ/fulmine/pkg/boltz"
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/davecgh/go-spew/spew"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -46,6 +47,7 @@ func (b *btcToArkHandler) HandleSwapCreated(ctx context.Context, update boltz.Sw
 }
 
 func (b *btcToArkHandler) HandleLockupFailed(ctx context.Context, update boltz.SwapUpdate) error {
+	spew.Dump(update)
 	return b.handleBtcToArkFailure(ctx, update, getQuote)
 }
 

--- a/pkg/swap/chainswap_btc_ark_handler.go
+++ b/pkg/swap/chainswap_btc_ark_handler.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/ArkLabsHQ/fulmine/pkg/boltz"
 	"github.com/btcsuite/btcd/btcec/v2"
-	"github.com/davecgh/go-spew/spew"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -47,7 +46,6 @@ func (b *btcToArkHandler) HandleSwapCreated(ctx context.Context, update boltz.Sw
 }
 
 func (b *btcToArkHandler) HandleLockupFailed(ctx context.Context, update boltz.SwapUpdate) error {
-	spew.Dump(update)
 	return b.handleBtcToArkFailure(ctx, update, getQuote)
 }
 


### PR DESCRIPTION
The new test is going to pass after https://github.com/BoltzExchange/boltz-backend/pull/1381 is merged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for submarine swap underfunded scenarios, including address/script validation and cooperative refund flow.
* **Refactor**
  * Stabilized e2e tests by replacing fixed sleeps with a retrying settle mechanism and shared helpers for faucet funding and settlement polling, reducing flakiness.
* **Chores**
  * Improved CI diagnostics to collect container/service logs on integration-test failures and added extra debug output for swap failure investigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->