### PR TITLE
Bump Go Docker images from 1.26.2 to 1.26.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY internal/interface/web .
 RUN rm -rf .parcel-cache && yarn && yarn build
 
 # Build the Go application
-FROM golang:1.26.2 AS go-builder
+FROM golang:1.26.3 AS go-builder
 
 ARG VERSION
 ARG COMMIT

--- a/arkd.Dockerfile
+++ b/arkd.Dockerfile
@@ -1,5 +1,5 @@
 # First image used to build the sources
-FROM golang:1.26.2 AS builder
+FROM golang:1.26.3 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/arkdwallet.Dockerfile
+++ b/arkdwallet.Dockerfile
@@ -1,5 +1,5 @@
 # First stage: build the ark-wallet-daemon binary
-FROM golang:1.26.2 AS builder
+FROM golang:1.26.3 AS builder
 
 ARG VERSION
 ARG TARGETOS

--- a/mockboltz.Dockerfile
+++ b/mockboltz.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.2-alpine AS builder
+FROM golang:1.26.3-alpine AS builder
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
arkd master now requires go >= 1.26.3, which breaks the CI Docker build when GOTOOLCHAIN=local is set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go version to 1.26.3 in all build environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->