### PR TITLE
Refresh server config on startup for existing wallets

### DIFF
--- a/arkd.Dockerfile
+++ b/arkd.Dockerfile
@@ -1,5 +1,5 @@
 # First image used to build the sources
-FROM golang:1.26.3 AS builder
+FROM golang:1.26.4 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/arkdwallet.Dockerfile
+++ b/arkdwallet.Dockerfile
@@ -1,5 +1,5 @@
 # First stage: build the ark-wallet-daemon binary
-FROM golang:1.26.3 AS builder
+FROM golang:1.26.4 AS builder
 
 ARG VERSION
 ARG TARGETOS

--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -224,6 +224,10 @@ func newService(
 			syncLock:              &sync.RWMutex{},
 		}
 
+		if err := svc.RefreshServerConfig(context.Background()); err != nil {
+			return nil, err
+		}
+
 		return svc, nil
 	} else if !strings.Contains(err.Error(), "not initialized") {
 		return nil, err
@@ -293,6 +297,44 @@ func (s *Service) GetSyncedUpdate() <-chan types.SyncEvent {
 
 func (s *Service) GetWalletUpdates() <-chan WalletUpdate {
 	return s.walletUpdates
+}
+
+// RefreshServerConfig fetches the current server info and updates the
+// persisted config for fields that may change after initial setup
+// (forfeit address, forfeit pubkey, checkpoint tapscript).
+func (s *Service) RefreshServerConfig(ctx context.Context) error {
+	if !s.isInitialized {
+		return fmt.Errorf("service not initialized")
+	}
+
+	currentCfg, err := s.GetConfigData(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to read current config: %w", err)
+	}
+
+	info, err := s.Client().GetInfo(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get server info: %w", err)
+	}
+
+	forfeitPubkeyBuf, err := hex.DecodeString(info.ForfeitPubKey)
+	if err != nil {
+		return fmt.Errorf("failed to decode forfeit pubkey: %w", err)
+	}
+	forfeitPubkey, err := btcec.ParsePubKey(forfeitPubkeyBuf)
+	if err != nil {
+		return fmt.Errorf("failed to parse forfeit pubkey: %w", err)
+	}
+
+	currentCfg.ForfeitAddress = info.ForfeitAddress
+	currentCfg.ForfeitPubKey = forfeitPubkey
+	currentCfg.CheckpointTapscript = info.CheckpointTapscript
+
+	if err := s.GetConfigStore().AddData(ctx, *currentCfg); err != nil {
+		return fmt.Errorf("failed to persist updated config: %w", err)
+	}
+
+	return nil
 }
 
 func (s *Service) SetupFromMnemonic(

--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -326,6 +326,13 @@ func (s *Service) RefreshServerConfig(ctx context.Context) error {
 		return fmt.Errorf("failed to parse forfeit pubkey: %w", err)
 	}
 
+	// Nothing to do if nothing changed server-side
+	if info.ForfeitAddress == currentCfg.ForfeitAddress &&
+		forfeitPubkey.IsEqual(currentCfg.ForfeitPubKey) &&
+		info.CheckpointTapscript == currentCfg.CheckpointTapscript {
+		return nil
+	}
+
 	currentCfg.ForfeitAddress = info.ForfeitAddress
 	currentCfg.ForfeitPubKey = forfeitPubkey
 	currentCfg.CheckpointTapscript = info.CheckpointTapscript


### PR DESCRIPTION
## Summary                                                                                                                                                                                
                            
  - Add `RefreshServerConfig` method to fulmine's `Service` that fetches current server info via `GetInfo` and updates `forfeit_address`, `forfeit_pubkey`, and `checkpoint_tapscript` in   
  `state.json`                            
  - Call it in `newService` after `LoadArkClient` succeeds, so the config is always fresh on restart without requiring a re-init

## Testing
start arkd-wallet and arkd with make run-wallet & make run-light, create wallet and unlock
start fulmine make run
stop all
delete arkd-wallet/arkd datadir not fulmine
copy fulmine state.json
start all together & recreate wallet
start fulmine
check if fulmine state.json is updated.

@altafan @louisinger please review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability Improvements**
  * Added automatic server configuration validation and persistence refresh to ensure consistent state
  * Updated build environment to Go 1.26.4 for improved performance and stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->