### PR TITLE
Fix compute and schedule next settlement

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/arkade-os/arkd/pkg/client-lib v0.0.0-20260615145327-0a5e6eb511e2
 	github.com/arkade-os/arkd/pkg/kvdb v0.7.0
 	github.com/arkade-os/arkd/pkg/macaroons v0.7.0
-	github.com/arkade-os/go-sdk v0.9.2-0.20260615150109-d30603fa81cb
+	github.com/arkade-os/go-sdk v0.9.2-0.20260615205532-87bf561185ff
 	github.com/ccoveille/go-safecast v1.6.1
 	github.com/creack/pty v1.1.24
 	github.com/dgraph-io/badger/v4 v4.8.0

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,8 @@ github.com/arkade-os/arkd/pkg/kvdb v0.7.0 h1:+XN0FeUEilKLuNHarP/mpwsCWla2iAHc6z9
 github.com/arkade-os/arkd/pkg/kvdb v0.7.0/go.mod h1:8SEm4dAIcGtnGqZ8+QRk58Z1VjIIctl6bZJLQwaOePo=
 github.com/arkade-os/arkd/pkg/macaroons v0.7.0 h1:BZfaeCDGNu/u/efnlesDjzzEPMYpCQO//jeE4d/3CwY=
 github.com/arkade-os/arkd/pkg/macaroons v0.7.0/go.mod h1:JuHFgu0NjbvFnTF7j7oHHatIMkKKPKvznUPkZwFi2Xk=
-github.com/arkade-os/go-sdk v0.9.2-0.20260615150109-d30603fa81cb h1:L9Ggx6EgX1SG8qDLDQqk6Po40+Dvct29d+PqubrUL0E=
-github.com/arkade-os/go-sdk v0.9.2-0.20260615150109-d30603fa81cb/go.mod h1:tP+DiJ5kLxi3CfbY8YnWAxfNlRnAlnmjJMcNWJXHx78=
+github.com/arkade-os/go-sdk v0.9.2-0.20260615205532-87bf561185ff h1:rA2n/HhX8QV3dRJleVLPVWPfRYs2t/6B2woOIBJ6T5E=
+github.com/arkade-os/go-sdk v0.9.2-0.20260615205532-87bf561185ff/go.mod h1:tP+DiJ5kLxi3CfbY8YnWAxfNlRnAlnmjJMcNWJXHx78=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -557,7 +557,13 @@ func (s *Service) UnlockNode(ctx context.Context, password string) error {
 		// Resume pending swap refunds.
 		go s.resumePendingSwapRefunds(ctx)
 
-		go s.subscribeForVtxoEvent(ctx, arkConfig)
+		// Detach from the request-scoped ctx: this listener lives for the whole
+		// unlocked session (stopped via stopVtxoEventListener), and it makes
+		// long-lived sdk calls (ListVtxos/Settle) on every refresh. If it kept
+		// the UnlockNode ctx, that ctx being canceled after unlock returns would
+		// make every refresh fail with "context canceled" and silently stop
+		// rescheduling settlements.
+		go s.subscribeForVtxoEvent(context.Background(), arkConfig)
 
 		// Schedule next settlement for the current vtxo set. Subsequent updates
 		// are handled by subscribeForVtxoEvent and its periodic safety check.
@@ -2123,10 +2129,18 @@ func (s *Service) renewExpiredVtxos(ctx context.Context, data *clientTypes.Confi
 	}
 
 	go func() {
-		defer s.renewing.Store(false)
-
 		log.Debug("detected expired vtxos, joining a batch to renew them...")
-		if _, err := s.ArkClient.Settle(ctx); err != nil {
+		// Use the guarded Settle so we never settle while the node is locked
+		// (the renewal can be detected just before a Lock and run afterwards).
+		_, err := s.Settle(ctx)
+
+		// Release the single-flight guard before recomputing: if more vtxos
+		// expired while we were settling (e.g. a capped batch left some behind),
+		// the follow-up refresh can renew them right away instead of waiting for
+		// the periodic safety ticker.
+		s.renewing.Store(false)
+
+		if err != nil {
 			log.WithError(err).Error("failed to renew expired vtxos")
 			return
 		}
@@ -2161,10 +2175,10 @@ func (s *Service) scheduleNextSettlement(at time.Time, data *clientTypes.Config)
 	nextSettlement := s.schedulerSvc.WhenNextSettlement()
 
 	// Checking if "at" is after now is a safe guard against buggish time values.
-	if !nextSettlement.IsZero() && at.After(now) && at.After(s.schedulerSvc.WhenNextSettlement()) {
+	if !nextSettlement.IsZero() && at.After(now) && at.After(nextSettlement) {
 		log.Debugf(
 			"scheduling next settlement at %s skipped - one already set at %s",
-			at.Format(time.RFC3339), s.schedulerSvc.WhenNextSettlement().Format(time.RFC3339),
+			at.Format(time.RFC3339), nextSettlement.Format(time.RFC3339),
 		)
 		return nil
 	}

--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -14,6 +14,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/ArkLabsHQ/fulmine/internal/core/domain"
@@ -119,6 +120,10 @@ type Service struct {
 	notifications chan Notification
 
 	stopVtxoEventListener chan struct{}
+
+	// renewing is a single-flight guard so that, while we are settling to renew
+	// already-expired vtxos, concurrent vtxo events don't pile up extra settles.
+	renewing atomic.Bool
 
 	// callback functions to stop and start delegate service
 	onUnlock func()
@@ -554,27 +559,10 @@ func (s *Service) UnlockNode(ctx context.Context, password string) error {
 
 		go s.subscribeForVtxoEvent(ctx, arkConfig)
 
-		// Schedule next settlement for the current vtxo set.
-		nextExpiry, err := s.computeNextExpiry(context.Background(), arkConfig)
-		if err != nil {
-			log.WithError(err).Error("failed to compute next expiry")
-		}
-
-		if nextExpiry != nil {
-			// If the next expiry is in the past, we settle immediately because some vtxos expired.
-			// The next settlement will be scheduled by subscribeForVtxoEvent in this case
-			if nextExpiry.Before(time.Now()) {
-				log.Debug("detected expired vtxos, joining a batch to renew them...")
-				if _, err := s.ArkClient.Settle(ctx); err != nil {
-					log.WithError(err).Error("failed to renew expired vtxos")
-				}
-			} else {
-				// Otherwise, let's schedule the very first next settlement, the future ones will
-				// be handled by subscribeForVtxoEvent
-				if err := s.scheduleNextSettlement(*nextExpiry, arkConfig); err != nil {
-					log.WithError(err).Error("failed to schedule next settlement")
-				}
-			}
+		// Schedule next settlement for the current vtxo set. Subsequent updates
+		// are handled by subscribeForVtxoEvent and its periodic safety check.
+		if err := s.refreshSettlementSchedule(context.Background(), arkConfig); err != nil {
+			log.WithError(err).Error("failed to schedule next settlement")
 		}
 
 		// nolint
@@ -2099,10 +2087,68 @@ func (s *Service) computeNextExpiry(
 	return expiry, nil
 }
 
+// refreshSettlementSchedule recomputes the next settlement time from the full
+// current vtxo set and (re)schedules it. If some vtxos are already expired it
+// settles immediately to renew them. It must be used instead of scheduling off
+// the delta of a single event, so that vtxos already held by the wallet (e.g.
+// left over by a previous batch) cannot expire unnoticed behind a later
+// scheduled settlement.
+func (s *Service) refreshSettlementSchedule(ctx context.Context, data *clientTypes.Config) error {
+	nextExpiry, err := s.computeNextExpiry(ctx, data)
+	if err != nil {
+		return err
+	}
+	if nextExpiry == nil {
+		return nil
+	}
+
+	// If the next expiry is in the past, settle immediately because some vtxos
+	// expired. The renewal runs in the background (single-flighted) so it does
+	// not block the caller (e.g. the vtxo event loop); the resulting vtxo events
+	// will reschedule the next settlement.
+	if nextExpiry.Before(time.Now()) {
+		s.renewExpiredVtxos(ctx, data)
+		return nil
+	}
+
+	return s.scheduleNextSettlement(*nextExpiry, data)
+}
+
+// renewExpiredVtxos settles in the background to renew already-expired vtxos.
+// It is single-flighted: if a renewal is already running, the call is a no-op,
+// so a burst of vtxo events cannot pile up redundant settlements.
+func (s *Service) renewExpiredVtxos(ctx context.Context, data *clientTypes.Config) {
+	if !s.renewing.CompareAndSwap(false, true) {
+		return
+	}
+
+	go func() {
+		defer s.renewing.Store(false)
+
+		log.Debug("detected expired vtxos, joining a batch to renew them...")
+		if _, err := s.ArkClient.Settle(ctx); err != nil {
+			log.WithError(err).Error("failed to renew expired vtxos")
+			return
+		}
+
+		// Recompute from the full set in case more vtxos are still near expiry.
+		if err := s.refreshSettlementSchedule(ctx, data); err != nil {
+			log.WithError(err).Error("failed to reschedule after renewing expired vtxos")
+		}
+	}()
+}
+
 func (s *Service) scheduleNextSettlement(at time.Time, data *clientTypes.Config) error {
 	task := func() {
 		if _, err := s.Settle(context.Background()); err != nil {
 			log.WithError(err).Warn("failed to renew vtxos")
+		}
+		// Recompute the next settlement from the full vtxo set after settling.
+		// This way any near-expiry vtxo that was not part of the batch is not
+		// left stranded, and a failed settle is retried instead of silently
+		// stopping the auto-settlement loop.
+		if err := s.refreshSettlementSchedule(context.Background(), data); err != nil {
+			log.WithError(err).Error("failed to reschedule settlement after renewing vtxos")
 		}
 	}
 
@@ -2130,42 +2176,49 @@ func (s *Service) scheduleNextSettlement(at time.Time, data *clientTypes.Config)
 	return nil
 }
 
-// subscribeForBoardingEvent aims to update the scheduled settlement
-// by checking for spent and new vtxos on the given boarding address
+// vtxoExpiryCheckInterval is how often the vtxo event listener recomputes the
+// next settlement from the full vtxo set, as a safety net in case a vtxo event
+// is missed (the sdk drops events when its buffer is congested).
+const vtxoExpiryCheckInterval = 10 * time.Minute
+
+// subscribeForVtxoEvent keeps the scheduled settlement in sync with the wallet's
+// vtxo set: whenever vtxos are added or spent, and periodically as a safety net,
+// it recomputes the earliest expiry across all spendable vtxos and reschedules
+// the next settlement (settling immediately if anything already expired).
 func (s *Service) subscribeForVtxoEvent(ctx context.Context, cfg *clientTypes.Config) {
 	eventsCh := s.GetVtxoEventChannel(ctx)
+
+	ticker := time.NewTicker(vtxoExpiryCheckInterval)
+	defer ticker.Stop()
+
+	refresh := func() {
+		if err := s.refreshSettlementSchedule(ctx, cfg); err != nil {
+			// Do not stop the listener on error: a transient failure must not
+			// permanently disable auto-settlement. The next event or tick retries.
+			log.WithError(err).Error("failed to refresh settlement schedule")
+		}
+	}
 
 	for {
 		select {
 		case <-s.stopVtxoEventListener:
 			return
+		case <-ticker.C:
+			refresh()
 		case event, ok := <-eventsCh:
 			if !ok {
 				return
 			}
 
-			vtxos := event.Vtxos
-			// If no vtxos were added skip checking for scheduling the next settlement
-			if event.Type != types.VtxosAdded || len(vtxos) == 0 {
+			// Only adding or spending vtxos can change the earliest expiry.
+			if event.Type != types.VtxosAdded && event.Type != types.VtxosSpent {
+				continue
+			}
+			if len(event.Vtxos) == 0 {
 				continue
 			}
 
-			nextScheduledSettlement := s.WhenNextSettlement(ctx)
-			needSchedule := false
-			for _, vtxo := range vtxos {
-				if nextScheduledSettlement.IsZero() ||
-					vtxo.ExpiresAt.Before(nextScheduledSettlement) {
-					nextScheduledSettlement = vtxo.ExpiresAt
-					needSchedule = true
-				}
-			}
-
-			if needSchedule {
-				if err := s.scheduleNextSettlement(nextScheduledSettlement, cfg); err != nil {
-					log.WithError(err).Error("failed to schedule next settlement")
-					return
-				}
-			}
+			refresh()
 		}
 	}
 }

--- a/internal/core/application/settlement_schedule_test.go
+++ b/internal/core/application/settlement_schedule_test.go
@@ -1,0 +1,187 @@
+package application
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	scheduler "github.com/ArkLabsHQ/fulmine/internal/infrastructure/scheduler/gocron"
+	clientTypes "github.com/arkade-os/arkd/pkg/client-lib/types"
+	arksdk "github.com/arkade-os/go-sdk"
+	"github.com/arkade-os/go-sdk/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSettlementScheduleTracksEarliestExpiry is the regression test for the bug
+// where the next settlement was computed only from the vtxos contained in a
+// single event (and ratcheted earlier-only). A vtxo already held by the wallet
+// but absent from the latest event would then expire behind a later scheduled
+// settlement. The fix recomputes the schedule from the full vtxo set, so the
+// schedule must always reflect the earliest expiry across all spendable vtxos.
+func TestSettlementScheduleTracksEarliestExpiry(t *testing.T) {
+	fake := newFakeArkClient()
+	svc, emit := newTestService(t, fake)
+
+	// 1. A single far-future vtxo arrives -> schedule far in the future.
+	far := vtxo("a", 240*time.Hour)
+	fake.setVtxos(far)
+	emit(types.VtxosAdded, far)
+
+	require.Eventually(t, func() bool {
+		next := svc.schedulerSvc.WhenNextSettlement()
+		return !next.IsZero() && next.After(time.Now().Add(239*time.Hour))
+	}, 2*time.Second, 10*time.Millisecond, "expected a far-future settlement to be scheduled")
+
+	// 2. A nearer vtxo is now also held by the wallet (e.g. left over by a
+	//    previous batch / received earlier), but the event that fires mentions
+	//    only an unrelated, even-later vtxo. The buggy code looked only at the
+	//    event's vtxos and would leave the schedule far in the future, stranding
+	//    the nearer vtxo. The fix must pull the schedule down to the nearer one.
+	near := vtxo("b", 1*time.Hour)
+	later := vtxo("c", 480*time.Hour)
+	fake.setVtxos(far, near, later)
+	emit(types.VtxosAdded, later)
+
+	require.Eventually(t, func() bool {
+		next := svc.schedulerSvc.WhenNextSettlement()
+		return !next.IsZero() && next.Before(time.Now().Add(2*time.Hour))
+	}, 2*time.Second, 10*time.Millisecond,
+		"next settlement should track the earliest-expiring vtxo, not the event's vtxos")
+
+	require.Zero(t, fake.settleCount(), "no vtxo expired, so no immediate settlement should happen")
+}
+
+// TestSettlementScheduleSettlesAlreadyExpiredVtxos verifies that when the wallet
+// already holds an expired vtxo, the listener renews it immediately (rather than
+// scheduling a settlement in the past, which previously errored and killed the
+// listener), and then reschedules off the renewed set.
+func TestSettlementScheduleSettlesAlreadyExpiredVtxos(t *testing.T) {
+	fake := newFakeArkClient()
+
+	// Simulate the renewal: once settled, the expired vtxo is replaced by a
+	// fresh far-future one, as a real settlement would do.
+	fake.onSettle = func() {
+		fake.spendable = []clientTypes.Vtxo{vtxo("renewed", 240*time.Hour)}
+	}
+
+	svc, emit := newTestService(t, fake)
+
+	expired := vtxo("old", -1*time.Hour)
+	fake.setVtxos(expired)
+	emit(types.VtxosAdded, expired)
+
+	// The expired vtxo must trigger exactly one immediate renewal...
+	require.Eventually(t, func() bool {
+		return fake.settleCount() >= 1
+	}, 2*time.Second, 10*time.Millisecond, "expired vtxo should trigger an immediate settlement")
+
+	// ...and then the schedule should follow the renewed, far-future set.
+	require.Eventually(t, func() bool {
+		next := svc.schedulerSvc.WhenNextSettlement()
+		return !next.IsZero() && next.After(time.Now().Add(239*time.Hour))
+	}, 2*time.Second, 10*time.Millisecond, "should reschedule off the renewed vtxo set")
+
+	// Single-flight + renewal must keep the renewal from looping.
+	time.Sleep(200 * time.Millisecond)
+	require.Equal(t, 1, fake.settleCount(), "renewal must not be repeated in a loop")
+}
+
+// fakeArkClient is a minimal stand-in for arksdk.ArkClient that only implements
+// the methods exercised by the settlement scheduling logic. Any other method is
+// inherited from the (nil) embedded interface and would panic if called, which
+// keeps the test honest about what the scheduler actually depends on.
+type fakeArkClient struct {
+	arksdk.ArkClient
+
+	mu        sync.Mutex
+	spendable []clientTypes.Vtxo
+	eventCh   chan types.VtxoEvent
+	settles   int
+	// onSettle, if set, is run while holding the lock when Settle is called,
+	// so a test can simulate the vtxo set being renewed by the settlement.
+	onSettle func()
+}
+
+func newFakeArkClient() *fakeArkClient {
+	return &fakeArkClient{eventCh: make(chan types.VtxoEvent, 16)}
+}
+
+func (f *fakeArkClient) setVtxos(vtxos ...clientTypes.Vtxo) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.spendable = vtxos
+}
+
+func (f *fakeArkClient) settleCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.settles
+}
+
+func (f *fakeArkClient) ListVtxos(_ context.Context) (spendable, spent []clientTypes.Vtxo, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]clientTypes.Vtxo, len(f.spendable))
+	copy(out, f.spendable)
+	return out, nil, nil
+}
+
+func (f *fakeArkClient) GetTransactionHistory(_ context.Context) ([]clientTypes.Transaction, error) {
+	return nil, nil
+}
+
+func (f *fakeArkClient) GetVtxoEventChannel(_ context.Context) <-chan types.VtxoEvent {
+	return f.eventCh
+}
+
+func (f *fakeArkClient) Settle(_ context.Context, _ ...arksdk.BatchSessionOption) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.settles++
+	if f.onSettle != nil {
+		f.onSettle()
+	}
+	return "txid", nil
+}
+
+func vtxo(txid string, expiresIn time.Duration) clientTypes.Vtxo {
+	return clientTypes.Vtxo{
+		Outpoint:  clientTypes.Outpoint{Txid: txid, VOut: 0},
+		Amount:    1000,
+		ExpiresAt: time.Now().Add(expiresIn),
+	}
+}
+
+// newTestService wires the real gocron scheduler to a Service backed by the fake
+// sdk client, and starts the vtxo event listener. It returns the service, the
+// fake client, and a function to send vtxo events to the listener.
+func newTestService(t *testing.T, fake *fakeArkClient) (*Service, func(types.VtxoEventType, ...clientTypes.Vtxo)) {
+	t.Helper()
+
+	sched := scheduler.NewScheduler("", 50*time.Millisecond)
+	sched.Start()
+
+	svc := &Service{
+		ArkClient:             fake,
+		schedulerSvc:          sched,
+		stopVtxoEventListener: make(chan struct{}),
+	}
+
+	// SessionDuration is tiny so the 2-session safety offset doesn't push
+	// far-future schedules around in a way that would confuse the assertions.
+	cfg := &clientTypes.Config{SessionDuration: 1}
+
+	go svc.subscribeForVtxoEvent(context.Background(), cfg)
+
+	t.Cleanup(func() {
+		close(svc.stopVtxoEventListener)
+		sched.Stop()
+	})
+
+	emit := func(typ types.VtxoEventType, vtxos ...clientTypes.Vtxo) {
+		fake.eventCh <- types.VtxoEvent{Type: typ, Vtxos: vtxos}
+	}
+
+	return svc, emit
+}

--- a/internal/core/application/settlement_schedule_test.go
+++ b/internal/core/application/settlement_schedule_test.go
@@ -135,6 +135,8 @@ func (f *fakeArkClient) GetVtxoEventChannel(_ context.Context) <-chan types.Vtxo
 	return f.eventCh
 }
 
+func (f *fakeArkClient) IsLocked(_ context.Context) bool { return false }
+
 func (f *fakeArkClient) Settle(_ context.Context, _ ...arksdk.BatchSessionOption) (string, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -166,6 +168,10 @@ func newTestService(t *testing.T, fake *fakeArkClient) (*Service, func(types.Vtx
 		ArkClient:             fake,
 		schedulerSvc:          sched,
 		stopVtxoEventListener: make(chan struct{}),
+		// Mark the service initialized/unlocked/synced so the guarded Settle
+		// (isInitializedAndUnlocked) used by the renewal path is allowed to run.
+		isInitialized: true,
+		syncEvent:     &types.SyncEvent{},
 	}
 
 	// SessionDuration is tiny so the 2-session safety offset doesn't push

--- a/internal/infrastructure/scheduler/gocron/service.go
+++ b/internal/infrastructure/scheduler/gocron/service.go
@@ -148,19 +148,19 @@ func (s *service) ScheduleNextSettlement(at time.Time, settleFunc func()) error 
 	}
 
 	delay := time.Until(at)
-	if delay < 0 {
-		return fmt.Errorf("cannot schedule task in the past")
-	}
 
 	s.CancelNextSettlement()
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if delay == 0 {
-		settleFunc()
+	// If the requested time is already due (the vtxos are at/over their expiry),
+	// settle immediately instead of dropping the request. Run async so callers
+	// holding their own locks (e.g. the vtxo event listener) don't deadlock.
+	if delay <= 0 {
+		go settleFunc()
 		return nil
 	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	job, err := s.scheduler.Every(delay).WaitForSchedule().LimitRunsTo(1).Do(func() {

--- a/internal/infrastructure/scheduler/service_test.go
+++ b/internal/infrastructure/scheduler/service_test.go
@@ -74,16 +74,23 @@ func testScheduler(t *testing.T, newScheduler func() ports.SchedulerService) {
 		svc.Start()
 		defer svc.Stop()
 
-		executed := false
+		done := make(chan bool, 1)
 		settleFunc := func() {
-			executed = true
+			done <- true
 		}
 
-		// Try to schedule in the past
+		// A settlement whose time is already in the past must be executed
+		// immediately (the vtxos are at/over their expiry), not dropped.
 		pastTime := time.Now().Add(-1 * time.Hour)
 		err := svc.ScheduleNextSettlement(pastTime, settleFunc)
-		require.Error(t, err)
-		require.False(t, executed)
+		require.NoError(t, err)
+
+		select {
+		case <-done:
+			// settled immediately as expected
+		case <-time.After(1 * time.Second):
+			require.Fail(t, "past-due settlement did not execute immediately")
+		}
 	})
 
 	t.Run("schedule settlement for now", func(t *testing.T) {

--- a/pkg/swap/go.mod
+++ b/pkg/swap/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/ArkLabsHQ/fulmine/pkg/vhtlc v0.0.0-20260116135645-5d6845a62019
 	github.com/arkade-os/arkd/pkg/ark-lib v0.8.1-0.20260429091057-9246f043c4c8
 	github.com/arkade-os/arkd/pkg/client-lib v0.0.0-20260615145327-0a5e6eb511e2
-	github.com/arkade-os/go-sdk v0.9.2-0.20260615150109-d30603fa81cb
+	github.com/arkade-os/go-sdk v0.9.2-0.20260615205532-87bf561185ff
 	github.com/ccoveille/go-safecast v1.6.1
 )
 

--- a/pkg/swap/go.sum
+++ b/pkg/swap/go.sum
@@ -24,8 +24,8 @@ github.com/arkade-os/arkd/pkg/client-lib v0.0.0-20260615145327-0a5e6eb511e2 h1:s
 github.com/arkade-os/arkd/pkg/client-lib v0.0.0-20260615145327-0a5e6eb511e2/go.mod h1:TCvgTjNjKeX0VW2h1+YoN+EFxT/yY+dRxmD96OV1dRw=
 github.com/arkade-os/arkd/pkg/errors v0.0.0-20260303153651-8615412e4dea h1:x9ZwZL+F2b9E0uBZYBVjCLGtlqIE4zahDOY4C89h3X4=
 github.com/arkade-os/arkd/pkg/errors v0.0.0-20260303153651-8615412e4dea/go.mod h1:NYGE+baj57ynbXNwjISJddMDpMqAWOX27dV22xqFm2A=
-github.com/arkade-os/go-sdk v0.9.2-0.20260615150109-d30603fa81cb h1:L9Ggx6EgX1SG8qDLDQqk6Po40+Dvct29d+PqubrUL0E=
-github.com/arkade-os/go-sdk v0.9.2-0.20260615150109-d30603fa81cb/go.mod h1:tP+DiJ5kLxi3CfbY8YnWAxfNlRnAlnmjJMcNWJXHx78=
+github.com/arkade-os/go-sdk v0.9.2-0.20260615205532-87bf561185ff h1:rA2n/HhX8QV3dRJleVLPVWPfRYs2t/6B2woOIBJ6T5E=
+github.com/arkade-os/go-sdk v0.9.2-0.20260615205532-87bf561185ff/go.mod h1:tP+DiJ5kLxi3CfbY8YnWAxfNlRnAlnmjJMcNWJXHx78=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=


### PR DESCRIPTION
This adds a periodical 10 mins refresh and recompute next settlement fallback strategy and fixes the behavor of the cronjob-based scheduler.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed settlement scheduling to always use the earliest expiry across the full spendable set.
  * Prevented redundant background renewals for assets already past expiry.
  * Improved behavior for settlements that are already past due so they execute immediately.

* **Improvements**
  * Enhanced settlement monitoring to continually keep schedules accurate and react to relevant asset changes.

* **Tests**
  * Added regression coverage for earliest-expiry tracking and already-expired settlement/renewal edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->