### PR TITLE
docs: rewrite README for accuracy (auth, delegate, VHTLC, env vars)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Go Version](https://img.shields.io/badge/Go-1.26.2-blue.svg)](https://golang.org/doc/go1.26)
 [![GitHub Release](https://img.shields.io/github/v/release/ArkLabsHQ/fulmine)](https://github.com/ArkLabsHQ/fulmine/releases/latest)
-[![License](https://img.shields.io/github/license/ArkLabsHQ/fulmine)](https://github.com/ArkLabsHQ/fulmine/blob/main/LICENSE)
+[![License](https://img.shields.io/github/license/ArkLabsHQ/fulmine)](https://github.com/ArkLabsHQ/fulmine/blob/master/LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/ArkLabsHQ/fulmine)](https://github.com/ArkLabsHQ/fulmine/stargazers)
 [![GitHub Issues](https://img.shields.io/github/issues/ArkLabsHQ/fulmine)](https://github.com/ArkLabsHQ/fulmine/issues)
 
@@ -25,6 +25,8 @@ docker run -d \
   -v fulmine-data:/app/data \
   ghcr.io/arklabshq/fulmine:latest
 ```
+
+Port `7001` serves the web UI and REST API; port `7000` serves the gRPC API. If you intend to run a delegate, also publish the delegate port — see [Running as a Delegate](#-running-as-a-delegate).
 
 Once the container is running, you can access the web UI at [http://localhost:7001](http://localhost:7001).
 
@@ -63,29 +65,68 @@ Alternatively, you can download the latest release from the [releases page](http
 
 ### 🔧 Environment Variables
 
-The following environment variables can be configured:
+All settings are read from environment variables prefixed with `FULMINE_`. The most common ones are listed below; for the complete and authoritative list, see [`internal/config/config.go`](internal/config/config.go).
+
+#### Core
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `FULMINE_DATADIR` | Directory to store wallet data | `/app/data` in Docker, `~/.fulmine` otherwise |
+| `FULMINE_DATADIR` | Directory to store wallet, database and macaroon data | `/app/data` in Docker; otherwise an OS-specific app dir (`~/.fulmine` on Linux, `~/Library/Application Support/Fulmine` on macOS, `%LOCALAPPDATA%\Fulmine` on Windows) |
 | `FULMINE_HTTP_PORT` | HTTP port for the web UI and REST API | `7001` |
 | `FULMINE_GRPC_PORT` | gRPC port for service communication | `7000` |
-| `FULMINE_ARK_SERVER` | URL of the Ark server to connect to | It pre-fills with the default Ark server |
-| `FULMINE_ESPLORA_URL` | URL of the Esplora server to connect to | It pre-fills with the default Esplora server |
-| `FULMINE_UNLOCKER_TYPE` | Type of unlocker to use for auto-unlock (`file` or `env`) | Not set by default (no auto-unlock) |
-| `FULMINE_UNLOCKER_FILE_PATH` | Path to the file containing the wallet password (when using `file` unlocker) | Not set by default |
-| `FULMINE_UNLOCKER_PASSWORD` | Password string to use for unlocking (when using `env` unlocker) | Not set by default |
-| `FULMINE_BOLTZ_URL` | URL of the custom Boltz backend to connect to for swaps | Not set by default |
-| `FULMINE_BOLTZ_WS_URL` | URL of the custom Boltz WebSocket backend to connect to for swap events | Not set by default |
-| `FULMINE_DISABLE_TELEMETRY` | Opt out of telemetry logs | False by default | 
+| `FULMINE_DB_TYPE` | Database backend: `sqlite` or `badger` | `sqlite` |
+| `FULMINE_LOG_LEVEL` | Log verbosity (logrus levels: `4` = info, `5` = debug, `6` = trace) | `4` |
+| `FULMINE_ARK_SERVER` | URL of the Ark server to connect to. Optional — it can also be set when creating the wallet | Not set |
+| `FULMINE_ESPLORA_URL` | URL of the Esplora-compatible chain API to connect to. Optional | Not set |
+| `FULMINE_NO_MACAROONS` | Disable macaroon authentication on the API (see [Authentication](#-authentication)) | `false` (auth enabled) |
+
+#### Auto-unlock (see [Auto-Unlock Feature](#-auto-unlock-feature))
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `FULMINE_UNLOCKER_TYPE` | Auto-unlock method: `file` or `env` | Not set (no auto-unlock) |
+| `FULMINE_UNLOCKER_FILE_PATH` | Path to a file containing the wallet password (when using the `file` unlocker) | Not set |
+| `FULMINE_UNLOCKER_PASSWORD` | Wallet password (when using the `env` unlocker) | Not set |
+
+#### Delegate (see [Running as a Delegate](#-running-as-a-delegate))
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `FULMINE_DELEGATE_ENABLED` | Run a delegate service that refreshes clients' VTXOs | `false` |
+| `FULMINE_DELEGATE_PORT` | Port for the delegate API (must differ from the gRPC/HTTP ports) | `7002` |
+| `FULMINE_DELEGATE_FEE` | Service fee charged per delegation, in satoshis | `0` |
+
+#### Lightning & swaps
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `FULMINE_BOLTZ_URL` | URL of a custom Boltz backend for swaps | Not set |
+| `FULMINE_BOLTZ_WS_URL` | URL of a custom Boltz WebSocket backend for swap events | Not set |
+| `FULMINE_SWAP_TIMEOUT` | Swap timeout, in seconds | `15` |
+| `FULMINE_LND_URL` | LND node URL (`lndconnect://...`, or `host:port` with `FULMINE_LND_DATADIR`). Mutually exclusive with CLN | Not set |
+| `FULMINE_LND_DATADIR` | LND data directory (to read TLS cert and macaroon) | Not set |
+| `FULMINE_CLN_URL` | CLN node URL (`clnconnect://...`, or `host:port` with `FULMINE_CLN_DATADIR`). Mutually exclusive with LND | Not set |
+| `FULMINE_CLN_DATADIR` | CLN data directory | Not set |
+
+#### Advanced
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `FULMINE_SCHEDULER_POLL_INTERVAL` | How often (seconds) the scheduler polls for VTXOs to refresh | `600` |
+| `FULMINE_REFRESH_DB_INTERVAL` | How often (seconds) the Ark SDK refreshes its local database | `60` |
+| `FULMINE_DISABLE_TELEMETRY` | Opt out of telemetry logs | `false` |
+| `FULMINE_PROFILING_ENABLED` | Expose a pprof server on `:6060` | `false` |
+| `FULMINE_OTEL_COLLECTOR_URL` | OpenTelemetry collector endpoint (enables OTel metrics/traces) | Not set |
+| `FULMINE_OTEL_PUSH_INTERVAL` | OpenTelemetry push interval, in seconds | `10` |
+| `FULMINE_PYROSCOPE_URL` | Pyroscope server URL for continuous profiling (requires OTel) | Not set |
 
 When using Docker, you can set these variables using the `-e` flag:
 
 ```bash
 docker run -d \
   --name fulmine \
+  -p 7000:7000 \
   -p 7001:7001 \
-  -e FULMINE_HTTP_PORT=7001 \
   -e FULMINE_ARK_SERVER="https://server.example.com" \
   -e FULMINE_ESPLORA_URL="https://mempool.space/api" \
   -e FULMINE_UNLOCKER_TYPE="file" \
@@ -97,7 +138,7 @@ docker run -d \
 
 ### 🔑 Auto-Unlock Feature
 
-Fulmine supports automatic wallet unlocking on startup, which is useful for unattended operation or when running as a service. Two methods are available:
+Fulmine supports automatic wallet unlocking on startup, which is useful for unattended operation or when running as a service (for example, a [delegate](#-running-as-a-delegate)). Two methods are available:
 
 1. **File-based unlocker**: Reads the wallet password from a file
    ```
@@ -111,34 +152,104 @@ Fulmine supports automatic wallet unlocking on startup, which is useful for unat
    FULMINE_UNLOCKER_PASSWORD=your_wallet_password
    ```
 
+Auto-unlock only runs if a wallet already exists; you must create the wallet once first.
+
 ⚠️ **Security Warning**: When using the auto-unlock feature, ensure your password is stored securely:
 - For file-based unlocking, use appropriate file permissions (chmod 600)
 - For environment-based unlocking, be cautious about environment variable visibility
 - Consider using Docker secrets or similar tools in production environments
 
+## 🤝 Running as a Delegate
+
+A **delegate** is a Fulmine instance that refreshes other users' VTXOs on their behalf, so their funds don't expire while they are offline. Clients submit a signed intent plus pre-signed forfeit transactions; the delegate stores them and, when a batch starts on the Ark server close to the VTXOs' expiry, joins the batch to refresh them.
+
+### Requirements
+
+- **The delegate is disabled by default.** Enable it with `FULMINE_DELEGATE_ENABLED=true`.
+- **A delegate needs a created _and unlocked_ wallet.** The delegate service starts when the wallet is unlocked and stops when it is locked, and it signs batch transactions with the wallet's key. For unattended operation, configure [auto-unlock](#-auto-unlock-feature).
+- The delegate listens on its own port, `FULMINE_DELEGATE_PORT` (default `7002`), which **must differ** from the gRPC and HTTP ports.
+- Optionally set `FULMINE_DELEGATE_FEE` (satoshis) to require a service fee; clients must pay at least this amount to the delegate's address in their intent.
+
+### Example
+
+```bash
+docker run -d \
+  --name fulmine-delegate \
+  -p 7000:7000 \
+  -p 7001:7001 \
+  -p 7002:7002 \
+  -e FULMINE_DELEGATE_ENABLED=true \
+  -e FULMINE_DELEGATE_FEE=1000 \
+  -e FULMINE_ARK_SERVER="https://server.example.com" \
+  -e FULMINE_UNLOCKER_TYPE=file \
+  -e FULMINE_UNLOCKER_FILE_PATH=/app/password.txt \
+  -v fulmine-data:/app/data \
+  -v /path/to/password.txt:/app/password.txt \
+  ghcr.io/arklabshq/fulmine:latest
+```
+
+Create and unlock the wallet once (see [Wallet Setup & Basic Usage](#-wallet-setup--basic-usage)); after that, auto-unlock brings the delegate back up on every restart.
+
+### Endpoints
+
+The delegate exposes two **public** endpoints (no macaroon required) on the delegate port (`7002` by default). Note that these are served at the root path, **not** under `/api`:
+
+- `GET /v1/delegate/info` — the delegate's pubkey, fee and fee address
+- `POST /v1/delegate` — submit a delegation request
+
+See the [Delegate API](#-delegate-api) section for request/response details. To inspect the status of submitted delegation tasks, clients use the authenticated `ListDelegates` endpoint on the main API (`GET /api/v1/delegates`).
+
 ## 📚 API Documentation
 
-### ⚠️ Security Notice
+### 🔐 Authentication
 
-**IMPORTANT**: The REST API and gRPC interfaces are currently **not protected** by authentication. This is a known limitation and is being tracked in [issue #98](https://github.com/ArkLabsHQ/fulmine/issues/98). 
+Fulmine protects its gRPC and REST endpoints with [macaroons](https://github.com/lightninglabs/macaroons), and **authentication is enabled by default**.
 
-**DO NOT** expose these interfaces over the public internet until authentication is implemented. The interfaces should only be accessed from trusted networks or localhost.
+- When you create or unlock a wallet, Fulmine bakes an admin macaroon at `<datadir>/macaroons/admin.macaroon` (its root key is stored in `<datadir>/macaroons/macaroons.db`). The `admin.macaroon` grants access to every protected method.
+- **REST**: send the macaroon, hex-encoded, in the `X-Macaroon` header.
+- **gRPC**: send the macaroon, hex-encoded, in the `macaroon` metadata field.
 
-While the wallet seed is encrypted using AES-256 with a password that the user set, the API endpoints themselves are not protected.
+Get the hex string and call a protected endpoint:
+
+```sh
+# Binary install (default datadir)
+MACAROON=$(xxd -p ~/.fulmine/macaroons/admin.macaroon | tr -d '\n')
+
+# Docker
+MACAROON=$(docker exec fulmine xxd -p /app/data/macaroons/admin.macaroon | tr -d '\n')
+
+curl -X GET http://localhost:7001/api/v1/balance -H "X-Macaroon: $MACAROON"
+```
+
+The following endpoints are **public** (no macaroon required):
+
+- Wallet lifecycle: `genseed`, `create`, `unlock`, `lock`, `auth`, `status`, `password/change`, `wallet/restore`
+- The [Delegate API](#-delegate-api) (`/v1/delegate/info` and `/v1/delegate`)
+
+All other endpoints — balance, addresses, sending, VHTLCs, notifications, chain swaps, `ListDelegates`, etc. — require the macaroon.
+
+To disable authentication entirely (e.g. for local development), set `FULMINE_NO_MACAROONS=true`.
+
+> ⚠️ **Do not expose an instance with authentication disabled to the public internet.** Even with macaroons enabled, only expose the interfaces you need, and prefer a trusted network or a reverse proxy that terminates TLS (Fulmine does not terminate TLS itself yet). While the wallet seed is encrypted at rest using AES-256 with your password, the API grants full control of the wallet to any holder of the admin macaroon.
 
 ### 🔌 API Interfaces
 
-Fulmine provides three main interfaces:
+Fulmine provides the following interfaces:
 
-1. **Web UI** - Available at [http://localhost:7001](http://localhost:7001) by default
-2. **REST API** - Available at [http://localhost:7001/api](http://localhost:7001/api)
-3. **gRPC Service** - Available at `localhost:7000`
+1. **Web UI** — available at [http://localhost:7001](http://localhost:7001) by default
+2. **REST API** — available under [http://localhost:7001/api](http://localhost:7001/api) (e.g. `GET /api/v1/wallet/status`)
+3. **gRPC Service** — available at `localhost:7000`
+4. **Delegate API** — when enabled, available at `localhost:7002` (gRPC and REST on the same port). See [Running as a Delegate](#-running-as-a-delegate).
+
+REST paths mirror the gRPC method bindings but are prefixed with `/api`. The examples below use the REST API.
 
 ### 🔑 Wallet Setup & Basic Usage
 
-Before using any wallet-dependent features, you need to set up and unlock your wallet.
+Before using any wallet-dependent feature, you need to set up and unlock your wallet. The wallet lifecycle endpoints are public, but every endpoint in this section after unlock requires the macaroon (omitted below for brevity — add `-H "X-Macaroon: $MACAROON"`).
 
 1. Generate Seed
+
+   Returns a new key in both hex and Nostr `nsec` form.
 
    ```sh
    curl -X GET http://localhost:7001/api/v1/wallet/genseed
@@ -173,7 +284,8 @@ Before using any wallet-dependent features, you need to set up and unlock your w
 
    ```sh
    curl -X POST http://localhost:7001/api/v1/wallet/lock \
-        -H "Content-Type: application/json"
+        -H "Content-Type: application/json" \
+        -d '{"password": "<strong password>"}'
    ```
 
 5. Get Wallet Status
@@ -182,16 +294,24 @@ Before using any wallet-dependent features, you need to set up and unlock your w
    curl -X GET http://localhost:7001/api/v1/wallet/status
    ```
 
+   Returns: `{ "initialized": <bool>, "synced": <bool>, "unlocked": <bool> }`
+
 6. Get Arkade Address
 
    ```sh
    curl -X GET http://localhost:7001/api/v1/address
    ```
 
+   Returns: `{ "address": "<ark address>", "pubkey": "<hex>" }`
+
 7. Get Onboard Address
 
+   Returns an onchain address to board the requested amount into Ark.
+
    ```sh
-   curl -X GET http://localhost:7001/api/v1/onboard
+   curl -X POST http://localhost:7001/api/v1/onboard \
+        -H "Content-Type: application/json" \
+        -d '{"amount": <amount in sats>}'
    ```
 
 8. Send funds offchain
@@ -210,9 +330,11 @@ Before using any wallet-dependent features, you need to set up and unlock your w
         -d '{"address": "<bitcoin address>", "amount": <amount in sats>}'
    ```
 
+This is only a subset of the wallet/service API. Other endpoints include balance, transaction history, settlement, invoices (Lightning), chain swaps and VTXO queries — see the [proto and OpenAPI specs](#-full-api-reference).
+
 ### 🔔 Notification API
 
-> **Note:** Wallet setup is not required to use the Notification API.
+> **Note:** The Notification API does not need wallet keys to function, but — like all `/api` endpoints — it is macaroon-protected by default. With authentication enabled you must have created/unlocked a wallet to obtain `admin.macaroon` (or set `FULMINE_NO_MACAROONS=true`).
 
 Fulmine can track off-chain addresses on behalf of external services and deliver notifications whenever funds are received or spent.
 
@@ -246,7 +368,7 @@ Fulmine can track off-chain addresses on behalf of external services and deliver
 
 ### ⚡ VHTLC API
 
-> **Note:** Wallet setup is required before using the VHTLC APIs.
+> **Note:** Wallet setup is required before using the VHTLC APIs, and these endpoints are macaroon-protected.
 
 Virtual Hash Time-Locked Contracts (VHTLCs) are Arkade-native HTLCs that live off-chain. They enable atomic swaps and conditional payments without touching the base layer.
 
@@ -254,12 +376,14 @@ Virtual Hash Time-Locked Contracts (VHTLCs) are Arkade-native HTLCs that live of
 
    Computes a VHTLC address from:
    * a preimage hash
-   * sender or receiver pubkeys. The missing key (depending on whether fulmine has to fund or claim the VHTLC) is added by fulmine using one of its internal wallet.
-   * optional locktimes, if not provided fulmine uses the following default values:
-      - `refundLocktime`: 24hrs. This is the offchain (absolute) locktime the sender must wait to refund the VHTLC offchain (can be expressed in blocks only on regtest)
-      - `unilateralClaimDelay`: 8 mins. This is the locktime the receiver has to wait to claim the VHTLC after it's been unrolled onchain
-      - `unilateralRefundDelay`: 16 mins. This is the locktime sender and Boltz have to wait to refund the VHTLC collaboratively after it's been unrolled onchain
-      - `unilateralRefundWithoutReceiverDelay`: 32 mins. This is the locktime the sender has to wait to refund alone the VHTLC after it's been unrolled onchain
+   * **exactly one** of `senderPubkey` or `receiverPubkey` — fulmine supplies the missing key from one of its internal wallets (depending on whether it funds or claims the VHTLC). Setting both, or neither, is rejected.
+   * optional locktimes. If not provided, fulmine uses the following defaults:
+      - `refundLocktime`: an absolute locktime after which the sender can refund the VHTLC off-chain. Defaults to **24 hours** from creation.
+      - `unilateralClaimDelay`: how long the receiver must wait to claim on-chain after the VHTLC is unrolled. Default **512 seconds**.
+      - `unilateralRefundDelay`: how long the sender and the counterparty must wait to refund collaboratively on-chain after unroll. Default **1024 seconds**.
+      - `unilateralRefundWithoutReceiverDelay`: how long the sender must wait to refund alone on-chain after unroll. Default **2048 blocks** (note: this default is block-denominated, not time).
+
+   Relative locktimes are objects of the form `{"type": "LOCKTIME_TYPE_SECOND" | "LOCKTIME_TYPE_BLOCK", "value": <number>}`.
 
    ```sh
    curl -X POST http://localhost:7001/api/v1/vhtlc \
@@ -267,33 +391,32 @@ Virtual Hash Time-Locked Contracts (VHTLCs) are Arkade-native HTLCs that live of
         -d '{
           "preimageHash": "<hex preimage hash>",
           "senderPubkey": "<hex sender pubkey>",
-          "receiverPubkey": "<hex receiver pubkey>",
-          "refundLocktime": 1024,
-          "unilateralClaimDelay": {"type": "LOCKTIME_TYPE_SECONDS", "value": 2048},
-          "unilateralRefundDelay": {"type": "LOCKTIME_TYPE_SECONDS", "value": 4096},
-          "unilateralRefundWithoutReceiverDelay": {"type": "LOCKTIME_TYPE_SECONDS", "value": 8192}
+          "refundLocktime": 1750000000,
+          "unilateralClaimDelay": {"type": "LOCKTIME_TYPE_SECOND", "value": 512},
+          "unilateralRefundDelay": {"type": "LOCKTIME_TYPE_SECOND", "value": 1024},
+          "unilateralRefundWithoutReceiverDelay": {"type": "LOCKTIME_TYPE_BLOCK", "value": 2048}
         }'
    ```
 
-   Returns: VHTLC `id`, `address`, `claimPubkey`, `refundPubkey`, `serverPubkey`, `swapTree`, and the resolved locktime values.  
-   The `vhtlcId` is the sha256 hash of preimage hash + sender ec pubkey + receiver ec pubkey.
+   Returns: VHTLC `id`, `address`, `claimPubkey`, `refundPubkey`, `serverPubkey`, `swapTree`, and the resolved locktime values.
+   The `id` is the sha256 hash of `preimageHash` + sender EC pubkey + receiver EC pubkey.
 
 2. List VHTLCs
 
-   Returns VHTLCs by their  `vhtlcId`s.
+   Returns VTXOs at the VHTLC addresses identified by their `vhtlcId`s.
 
    ```sh
-   curl -X GET "http://localhost:7001/api/v1/vhtlcs?vhtlcIds=id1,id2"
+   curl -X GET "http://localhost:7001/api/v1/vhtlcs?vhtlcIds=id1&vhtlcIds=id2"
    ```
 
-3. ListVHTLC
+3. List a single VHTLC
 
-   Returns a VHTLC by its `vhtlcId`.
+   Returns the VTXOs at the VHTLC address identified by its `vhtlcId`.
 
    ```sh
    curl -X GET "http://localhost:7001/api/v1/vhtlc?vhtlcId=id1"
    ```
-   
+
 4. Claim VHTLC
 
    Claims a VHTLC by revealing the preimage. Moves the funds into a regular VTXO.
@@ -304,7 +427,7 @@ Virtual Hash Time-Locked Contracts (VHTLCs) are Arkade-native HTLCs that live of
         -d '{"vhtlcId": "<vhtlc id>", "preimage": "<hex preimage>"}'
    ```
 
-   Returns: `{ "claimTxid": "<txid>" }`
+   Returns: `{ "redeemTxid": "<txid>" }`
 
 5. Settle VHTLC
 
@@ -333,7 +456,7 @@ Virtual Hash Time-Locked Contracts (VHTLCs) are Arkade-native HTLCs that live of
         }'
    ```
 
-   Returns: `{ "commitmentTxid": "<txid>" }`
+   Returns: `{ "txid": "<txid>" }`
 
 6. Refund VHTLC Without Receiver
 
@@ -345,34 +468,34 @@ Virtual Hash Time-Locked Contracts (VHTLCs) are Arkade-native HTLCs that live of
         -d '{"vhtlcId": "<vhtlc id>"}'
    ```
 
-   Returns: `{ "refundTxid": "<txid>" }`
+   Returns: `{ "redeemTxid": "<txid>" }`
 
 ### 🤝 Delegate API
 
-> **Note:** Wallet setup is not required to use the Delegator API.
-
-Fulmine can act as a delegate: it monitors VTXO expiry on behalf of clients and automatically refreshes them before they expire. Clients submit a signed intent and pre-signed forfeit transactions; Fulmine handles the rest.
+The first two endpoints are served on the **delegate port** (`7002` by default), at the root path, and are **public** (no macaroon). They are only available when the delegate is [enabled](#-running-as-a-delegate). `ListDelegates` is part of the main, authenticated API.
 
 1. Get Delegate Info
 
    Returns the delegate's pubkey (to include in VTXO scripts), service fee, and fee address.
 
    ```sh
-   curl -X GET http://localhost:7001/api/v1/delegator/info
+   curl -X GET http://localhost:7002/v1/delegate/info
    ```
 
-   Returns: `{ "pubkey": "<hex>", "fee": "<amount>", "delegatorAddress": "<ark address>" }`
+   Returns: `{ "pubkey": "<hex>", "fee": "<sats>", "delegateAddress": "<ark address>", "delegatorAddress": "<ark address>" }`
+
+   > `delegatorAddress` is a legacy alias of `delegateAddress` (same value) and will be deprecated.
 
 2. Delegate
 
-   Submit a delegation request. The `intent.message` is a stringified JSON describing the VTXOs to refresh. The `intent.proof` is a partially signed PSBT (base64). `forfeitTxs` are partially signed forfeit transactions (base64), one per VTXO input.
+   Submit a delegation request. `intent.message` is a stringified Ark intent (`RegisterMessage`) describing the VTXOs to refresh, and `intent.proof` is the partially signed intent transaction (base64 PSBT). `forfeitTxs` are partially signed forfeit transactions (base64 PSBT), one per VTXO input. Set `rejectReplace` to `true` to fail rather than replace an existing pending task that shares an input.
 
    ```sh
-   curl -X POST http://localhost:7001/api/v1/delegate \
+   curl -X POST http://localhost:7002/v1/delegate \
         -H "Content-Type: application/json" \
         -d '{
           "intent": {
-            "message": "{\"vtxos\": [...]}",
+            "message": "<stringified RegisterMessage>",
             "proof": "<base64 psbt>"
           },
           "forfeitTxs": ["<base64 psbt>"],
@@ -380,21 +503,29 @@ Fulmine can act as a delegate: it monitors VTXO expiry on behalf of clients and 
         }'
    ```
 
+   Returns an empty object `{}` on success.
+
 3. List Delegates
 
-   Returns delegate tasks filtered by status, paginated.
+   Part of the **main** API (authenticated, on port `7001`). Returns delegate tasks filtered by status, paginated. The `status` parameter is **required** and must be one of `pending`, `completed`, `failed` or `cancelled`. `limit` defaults to `100` (max `1000`).
 
    ```sh
-   curl -X GET "http://localhost:7001/api/v1/delegates?status=<pending|completed|failed>&limit=10&offset=0"
+   curl -X GET "http://localhost:7001/api/v1/delegates?status=pending&limit=10&offset=0" \
+        -H "X-Macaroon: $MACAROON"
    ```
 
-Note: Replace `http://localhost:7001` with the appropriate host and port where your Fulmine is running.
+Note: Replace the host and ports above with wherever your Fulmine is running.
 
-For more detailed information about request and response structures, please refer to the proto files in the `api-spec/protobuf/fulmine/v1/` directory.
+### 📖 Full API Reference
+
+The examples above cover the most common operations. For the complete request/response schemas of every endpoint, see:
+
+- **Protobuf** definitions: [`api-spec/protobuf/fulmine/v1/`](api-spec/protobuf/fulmine/v1/)
+- **OpenAPI / Swagger** specs: [`api-spec/openapi/swagger/fulmine/v1/`](api-spec/openapi/swagger/fulmine/v1/)
 
 ## 👨‍💻 Development
 
-To get started with fulmine development you need Go `1.26.2` or higher and Node.js `18.17.1` or higher.
+To get started with fulmine development you need Go `1.26.2` or higher and Node.js `18.17.1` or higher (the Docker image builds the web assets with Node 22).
 
 ```bash
 git clone https://github.com/ArkLabsHQ/fulmine.git
@@ -424,10 +555,11 @@ make down-test-env
 
 We welcome contributions to fulmine! Here's how you can help:
 
-1. **Fork the repository** and create your branch from `main`
+1. **Fork the repository** and create your branch from `master`
 2. **Install dependencies**: `go mod download`
-3. **Make your changes** and ensure tests pass: `make test`4. **Run the linter** to ensure code quality: `make lint`
-4. **Submit a pull request**
+3. **Make your changes** and ensure tests pass: `make test`
+4. **Run the linter** to ensure code quality: `make lint`
+5. **Submit a pull request**
 
 For major changes, please open an issue first to discuss what you would like to change.
 

--- a/README.md
+++ b/README.md
@@ -282,10 +282,11 @@ Before using any wallet-dependent feature, you need to set up and unlock your wa
 
 4. Lock Wallet
 
+   Locks the wallet. Takes no parameters.
+
    ```sh
    curl -X POST http://localhost:7001/api/v1/wallet/lock \
-        -H "Content-Type: application/json" \
-        -d '{"password": "<strong password>"}'
+        -H "Content-Type: application/json"
    ```
 
 5. Get Wallet Status


### PR DESCRIPTION
## Summary

The README had drifted significantly from the code — most importantly around authentication and the delegate feature. This rewrites it so every claim matches the source. Each correction below was verified against the relevant file.

## What was wrong (and is now fixed)

### Authentication
- The README claimed the API is **"not protected by authentication"** (citing issue #98). In reality **macaroons are enabled by default** (`internal/config/config.go` — `NO_MACAROONS` defaults to `false`; `initMacaroonService` runs unless it's set).
- Documented the `admin.macaroon` (baked at `<datadir>/macaroons/admin.macaroon` on wallet create/unlock) and the `X-Macaroon` header. The header value is the **hex-encoded** macaroon (`internal/interface/grpc/service.go` header matcher + `pkg/macaroon/macaroons_test.go`).
- Documented `FULMINE_NO_MACAROONS=true` to disable auth.

### Delegate (the most outdated section)
- Served on its **own public port** `FULMINE_DELEGATE_PORT` (default **7002**) at root paths `/v1/delegate/info` and `/v1/delegate` — **not** `/api/...` on 7001, and **not** macaroon-protected (`service.go` builds the delegate server with no auth interceptor; `delegate.proto`).
- Requires `FULMINE_DELEGATE_ENABLED=true` (default false) **and a created + unlocked wallet** (`delegator_service.go` — both RPCs gate on `isInitializedAndUnlocked`; the service `start()`s on unlock).
- `intent.message` is a stringified Ark `RegisterMessage`, not an ad-hoc `{"vtxos":[...]}` (`delegate_handler.go`).
- `ListDelegates` actually lives on the **main authenticated API** (`GET /api/v1/delegates`, `service.proto`); `status` is **required** and may be `pending|completed|failed|cancelled` (`service_handler.go`, `domain/delegate.go`).
- Added a new **"Running as a Delegate"** guide (enable flag, port, fee, wallet/auto-unlock requirement, Docker example).

### VHTLC
- Corrected default locktimes (`internal/core/application/service.go`): `unilateralClaimDelay` = **512s**, `unilateralRefundDelay` = **1024s**, `unilateralRefundWithoutReceiverDelay` = **2048 blocks** (block-denominated, not "32 mins"), `refundLocktime` = **24h**. (Was "8/16/32 mins".)
- Fixed the locktime enum (`LOCKTIME_TYPE_SECOND`, not `..._SECONDS`) and the `unilateralRefundWithoutReceiverDelay` field name (was a typo, `...WithoutEeceiverDelay`).
- Fixed response fields: `ClaimVHTLC` → `redeemTxid`, `SettleVHTLC` → `txid`, `RefundVHTLCWithoutReceiver` → `redeemTxid` (`service.proto`).
- Noted `CreateVHTLC` takes **exactly one** of sender/receiver pubkey (`service_handler.go` rejects both/neither).

### Other
- Expanded the env-var table to the full operationally-relevant set (db type, log level, delegate, lightning, swap timeout, scheduler/telemetry), pointing to `internal/config/config.go` as the authoritative list.
- `onboard` is `POST /v1/onboard` with an `amount` body (was documented as `GET`, `service.proto`). `Lock` takes no parameters — `LockRequest` has a `password` field but the handler ignores it (`wallet_handler.go`), so it isn't shown in the example.
- Pointed to the generated OpenAPI specs (`api-spec/openapi/swagger/fulmine/v1/`) in addition to the protobufs.
- Fixed default-branch references (`master`, not `main`) and the broken Contributing list numbering.

## Test plan

- Docs-only change; no code touched.
- Cross-checked every endpoint path, default, and field name against `api-spec/protobuf/fulmine/v1/*.proto`, `internal/config/config.go`, `internal/interface/grpc/`, `internal/core/application/`, and the `Dockerfile`.

## Follow-up (out of scope, not in this PR)
- `internal/core/application/service.go` has a stale inline comment `// 224 blocks` next to `defaultUnilateralRefundWithoutReceiverDelay = 2048`. Worth a separate one-line code fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced port configuration guidance for web UI/REST and gRPC services
  * Clarified macaroon-based authentication for API endpoints
  * Updated API response field names and wallet setup examples
  * Improved delegate configuration requirements and behavior documentation
  * Reorganized environment variables reference with clearer defaults

<!-- end of auto-generated comment: release notes by coderabbit.ai -->