### PR TITLE
fix(chainswap): report the BTC lockup CLTV timeout height to callers

### DIFF
--- a/internal/core/domain/chainswap.go
+++ b/internal/core/domain/chainswap.go
@@ -2,6 +2,7 @@ package domain
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/ArkLabsHQ/fulmine/pkg/boltz"
 )
@@ -120,6 +121,25 @@ func (cs *ChainSwap) RefundFailed(errorMsg string) {
 func (cs *ChainSwap) UserLockFailed(errorMsg string) {
 	cs.Status = ChainSwapUserLockedFailed
 	cs.ErrorMessage = errorMsg
+}
+
+// TimeoutBlockHeight returns the absolute block height of the BTC lockup's CLTV
+// timeout — the height at which a unilateral on-chain refund of the user's BTC
+// lockup becomes spendable — derived from the stored Boltz creation response.
+// Returns 0 when it cannot be determined (no stored response, malformed JSON, or
+// a direction without a user BTC lockup).
+func (cs ChainSwap) TimeoutBlockHeight() uint32 {
+	if cs.BoltzCreateResponseJSON == "" {
+		return 0
+	}
+	var resp boltz.CreateChainSwapResponse
+	if err := json.Unmarshal([]byte(cs.BoltzCreateResponseJSON), &resp); err != nil {
+		return 0
+	}
+	if resp.LockupDetails.TimeoutBlockHeight < 0 {
+		return 0
+	}
+	return uint32(resp.LockupDetails.TimeoutBlockHeight)
 }
 
 // ChainSwapRepository stores chain swaps initiated by the wallet

--- a/internal/core/domain/chainswap_test.go
+++ b/internal/core/domain/chainswap_test.go
@@ -1,0 +1,28 @@
+package domain_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/ArkLabsHQ/fulmine/internal/core/domain"
+	"github.com/ArkLabsHQ/fulmine/pkg/boltz"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChainSwapTimeoutBlockHeight(t *testing.T) {
+	// A BTC->ARK creation response carries the BTC lockup's CLTV timeout under
+	// lockupDetails.timeoutBlockHeight; the accessor must surface it (this is the
+	// value a caller needs to know when a unilateral refund becomes spendable).
+	resp := boltz.CreateChainSwapResponse{
+		LockupDetails: boltz.SwapLeg{TimeoutBlockHeight: 362},
+	}
+	raw, err := json.Marshal(resp)
+	require.NoError(t, err)
+
+	cs := domain.ChainSwap{BoltzCreateResponseJSON: string(raw)}
+	require.Equal(t, uint32(362), cs.TimeoutBlockHeight())
+
+	// Degrade to 0 (never panic) when the height can't be determined.
+	require.Equal(t, uint32(0), domain.ChainSwap{}.TimeoutBlockHeight())
+	require.Equal(t, uint32(0), domain.ChainSwap{BoltzCreateResponseJSON: "{not json"}.TimeoutBlockHeight())
+}

--- a/internal/interface/grpc/handlers/service_handler.go
+++ b/internal/interface/grpc/handlers/service_handler.go
@@ -659,7 +659,7 @@ func (h *serviceHandler) CreateChainSwap(
 			Status:             chainSwapStatusToString(chainSwap.Status),
 			LockupAddress:      chainSwap.UserBtcLockupAddress,
 			ExpectedAmount:     chainSwap.Amount,
-			TimeoutBlockHeight: 0,
+			TimeoutBlockHeight: uint64(chainSwap.TimeoutBlockHeight()),
 			Preimage:           chainSwap.ClaimPreimage,
 		}, nil
 


### PR DESCRIPTION
## Summary

`CreateChainSwap` for a **BTC→ARK** chain swap returned `TimeoutBlockHeight: 0` — a stub. A client therefore had no way to learn when the unilateral on-chain refund of its BTC lockup becomes spendable; it had to *attempt* a refund and scrape the height out of the `"CLTV timeout not yet reached: ... required N"` error string.

The value is already available and persisted: Boltz returns it as `lockupDetails.timeoutBlockHeight`, and fulmine stores the full creation response in `boltz_create_response_json`. This PR adds a derived `domain.ChainSwap.TimeoutBlockHeight()` accessor that parses it, and returns it from the gRPC handler. **No schema change / migration** — the data was already stored, it just wasn't surfaced.

### Why the reported value is correct

At swap creation, `validateRefundPath` already asserts that the Boltz-reported `timeoutBlockHeight` equals the CLTV encoded in the refund leaf script:

```go
if components.Timeout != expectedTimeout {
    return fmt.Errorf("timeout mismatch: ...")
}
```

The unilateral refund (`refundBtcToArkSwap`) reads `components.Timeout` from that **same** refund leaf. So the height this PR reports is provably the exact height the refund requires — a mismatch would have failed `CreateChainSwap` up front.

## Changes

- `internal/core/domain/chainswap.go` — `TimeoutBlockHeight()` accessor (degrades to `0` on missing/malformed input, never panics)
- `internal/core/domain/chainswap_test.go` — unit test
- `internal/interface/grpc/handlers/service_handler.go` — return the real height instead of `0`

## Test plan

- [x] `go build ./...`, `go vet ./...`
- [x] Unit test passes — and proven to catch the bug: reverting the accessor to the stub `return 0` makes it fail (`expected 0x16a, got 0x0`), then restored
- [x] `internal/core/domain` and `internal/interface/grpc/handlers` packages green
- [ ] End-to-end: a real BTC→ARK swap → `CreateChainSwap` returns a non-zero `TimeoutBlockHeight` matching the refund requirement (needs the regtest stack)

## Notes

Found while reviewing the e2e refund test in #422, whose `refundChainSwapRPCWithRetry` helper currently scrapes the required height out of the refund error because this field was unset. Once both land, that helper can read the height from `CreateChainSwap` and drop the workaround.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chain swap timeout block height reporting to accurately display BTC lockup timeout information in transaction responses, replacing previously placeholder values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->