### PR TITLE
test(e2e): unilateral chain-swap refund coverage via Boltz control

### DIFF
--- a/internal/test/e2e/chainswap_test.go
+++ b/internal/test/e2e/chainswap_test.go
@@ -169,17 +169,265 @@ func TestChainSwapArkToBTCCooperativeRefund(t *testing.T) {
 	t.Logf("vtxo balance after refund: %d", balance.GetAmount())
 }
 
-// NOTE: BTC→ARK *unilateral refund* is intentionally not e2e-tested against live
-// Boltz. The unilateral refund only applies when the user's BTC lockup is never
-// claimed — but with a cooperating Boltz the swap always completes: fulmine
-// auto-claims the ARK VHTLC (revealing the preimage), Boltz then claims the BTC
-// lockup, and a later refund fails `bad-txns-inputs-missingorspent` because the
-// lockup is already spent (verified end-to-end: the swap's claim_tx_id is set).
-// This is the same class as the removed ARK→BTC unilateral-refund tests — there
-// is no way to force Boltz to refuse to claim. The unilateral BTC-refund code
-// path is consequently not covered by any test today; restoring it as a
-// pkg/swap unit test (with a faked Boltz client) is left as follow-up. Only the
-// live happy-path + cooperative refunds are covered here.
+// TestChainSwapBTCToARKUnilateralRefund exercises the unilateral BTC refund:
+// the user locks BTC but Boltz never claims it, so after the lockup's CLTV
+// timeout the user reclaims the BTC on-chain by spending the refund leaf.
+//
+// With a cooperating Boltz the swap always completes (fulmine claims the ARK
+// VHTLC, Boltz then claims the BTC lockup), so the unilateral path is
+// unreachable. We force "Boltz never claims" by stopping the Boltz container
+// after creation but before it locks the ARK side — the same lever the
+// dotnet-sdk e2e suite uses (NArk.Tests.End2End/Common/DockerHelper).
+func TestChainSwapBTCToARKUnilateralRefund(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 7*time.Minute)
+	defer cancel()
+
+	client, err := newFulmineClient(clientFulmineURL)
+	require.NoError(t, err)
+
+	// Boltz must be up to quote + create the swap.
+	createResp, err := client.CreateChainSwap(ctx, &pb.CreateChainSwapRequest{
+		Direction: pb.SwapDirection_SWAP_DIRECTION_BTC_TO_ARK,
+		Amount:    3000,
+	})
+	require.NoError(t, err)
+	require.Empty(t, createResp.GetError())
+	swapID := createResp.GetId()
+	require.NotEmpty(t, swapID)
+
+	// Restart Boltz at the end so later tests get a healthy Boltz.
+	defer startBoltzAndWait(t)
+
+	// Fund the lockup but DON'T confirm it yet (faucet() always mines, so call
+	// the regtest faucet directly without --confirm). Boltz reports the mempool
+	// lockup so fulmine records the txid (user_locked), but Boltz won't lock the
+	// ARK side until the lockup confirms — a race-free window to stop Boltz.
+	_, err = regtestCmd(ctx, "faucet", createResp.LockupAddress,
+		fmt.Sprintf("%.8f", float64(createResp.GetExpectedAmount())/1e8))
+	require.NoError(t, err)
+
+	// Stop Boltz the instant the swap is user_locked (fulmine has recorded the
+	// lockup txid, but Boltz hasn't locked ARK yet). Log the progression so we
+	// can see the window.
+	start := time.Now()
+	var last string
+	stopped := false
+	winDeadline := time.Now().Add(90 * time.Second)
+	for time.Now().Before(winDeadline) && !stopped {
+		resp, e := client.ListChainSwaps(ctx, &pb.ListChainSwapsRequest{SwapIds: []string{swapID}})
+		if e == nil && len(resp.GetSwaps()) > 0 {
+			s := resp.GetSwaps()[0].GetStatus()
+			if s != last {
+				t.Logf("STATUS t+%.1fs: %s", time.Since(start).Seconds(), s)
+				last = s
+			}
+			switch s {
+			case "user_locked":
+				stopBoltz(t, ctx)            // freeze Boltz before it can lock ARK
+				mineRegtestBlocks(t, ctx, 1) // confirm the lockup with Boltz down
+				stopped = true
+			case "server_locked", "claimed":
+				t.Fatalf("missed window: swap already %s at t+%.1fs", s, time.Since(start).Seconds())
+			}
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	require.True(t, stopped, "never observed user_locked within 90s (last=%s)", last)
+
+	// Surface the lockup's CLTV-required height (the BTC refund leaf's timeout).
+	var required int
+	for i := 0; i < 30; i++ {
+		cctx, cancelC := context.WithTimeout(ctx, 20*time.Second)
+		_, e := client.RefundChainSwap(cctx, &pb.RefundChainSwapRequest{Id: swapID})
+		cancelC()
+		require.Error(t, e, "refund before the CLTV timeout should error")
+		if m := cltvRequiredRE.FindStringSubmatch(stripANSI(e.Error())); m != nil {
+			_, _ = fmt.Sscanf(m[1], "%d", &required)
+			break
+		}
+		time.Sleep(time.Second)
+	}
+	require.NotZero(t, required, "never surfaced the CLTV required height")
+
+	// Burst-mine past the CLTV in one call — the esplora tracks the node with no
+	// lag, so this clears the refund's CLTV gate. (A per-block background miner
+	// is ~10s/block on this host and can't outrun an ~80-block timeout.)
+	mineRegtestBlocksToHeight(t, ctx, required+2)
+	t.Logf("CLTV required %d; mined node to %d", required, regtestBlockHeight(t, ctx))
+
+	// Feed a few confirmation blocks while the synchronous refund broadcasts the
+	// on-chain refund tx and boards the coin via an arkd round.
+	mineCtx, stopMiner := context.WithCancel(ctx)
+	defer stopMiner()
+	go func() {
+		for {
+			select {
+			case <-mineCtx.Done():
+				return
+			case <-time.After(3 * time.Second):
+				_, _ = regtestCmd(mineCtx, "mine", "1")
+			}
+		}
+	}()
+
+	// Retry the refund: after the burst the esplora needs a few seconds to index
+	// up to the CLTV height; once it does, the call broadcasts and (with the
+	// background miner) confirms + settles. A long per-call budget keeps the
+	// synchronous refund from being cancelled mid-flight.
+	refDeadline := time.Now().Add(4 * time.Minute)
+	for {
+		cctx, cancelC := context.WithTimeout(ctx, 3*time.Minute)
+		_, e := client.RefundChainSwap(cctx, &pb.RefundChainSwapRequest{Id: swapID})
+		cancelC()
+		if e == nil {
+			break
+		}
+		msg := stripANSI(e.Error())
+		retryable := strings.Contains(msg, "CLTV timeout not yet reached") ||
+			strings.Contains(msg, "failed to fetch lockup transaction") ||
+			strings.Contains(msg, "no vtxos found for vhtlc")
+		require.Truef(t, retryable && time.Now().Before(refDeadline),
+			"unilateral refund failed: %s", msg)
+		time.Sleep(2 * time.Second)
+	}
+
+	waitChainSwapStatus(t, ctx, client, swapID, "refunded_unilaterally", 90*time.Second)
+}
+
+// stopBoltz / startBoltzAndWait control the shared Boltz container to force
+// non-cooperative scenarios (mirrors the dotnet-sdk DockerHelper approach).
+// startBoltzAndWait uses a fresh context so the restore runs even if the test's
+// own context was cancelled.
+func stopBoltz(t *testing.T, ctx context.Context) {
+	t.Helper()
+	if _, err := runCommand(ctx, "docker stop boltz"); err != nil {
+		t.Fatalf("stop boltz: %v", err)
+	}
+}
+
+func startBoltzAndWait(t *testing.T) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := runCommand(ctx, "docker start boltz"); err != nil {
+		t.Logf("start boltz: %v", err)
+		return
+	}
+	deadline := time.Now().Add(2 * time.Minute)
+	for time.Now().Before(deadline) {
+		out, err := runCommand(ctx, "docker inspect -f '{{.State.Status}}' boltz")
+		if err == nil && strings.TrimSpace(out) == "running" {
+			time.Sleep(5 * time.Second) // let Boltz's REST settle
+			return
+		}
+		time.Sleep(2 * time.Second)
+	}
+	t.Logf("boltz not running within 2m after restart")
+}
+
+// TestChainSwapArkToBTCUnilateralRefund exercises the unilateral ARK refund: the
+// user locks an ARK VHTLC but Boltz never claims it, so after the VHTLC's
+// "without receiver" relative locktime (224 blocks — Boltz is gone) the user
+// reclaims the ARK. fulmine auto-locks the VHTLC (an arkd op, independent of
+// Boltz), so we just stop Boltz before its ~30s rescan locks the BTC side.
+func TestChainSwapArkToBTCUnilateralRefund(t *testing.T) {
+	t.Skip("ARK->BTC unilateral refund is not reliably e2e-testable: the swap " +
+		"auto-completes in <1s with no unconfirmed-lockup hold point (unlike " +
+		"BTC->ARK). docker pause CAN freeze Boltz at user_locked, but the race is " +
+		"flaky — it often loses to Boltz locking the BTC side first. Cover this " +
+		"fund-safety path with a pkg/swap unit test instead; the BTC->ARK " +
+		"direction (TestChainSwapBTCToARKUnilateralRefund) is the reliably " +
+		"e2e-testable one. Code below is kept as a reference for the pause-" +
+		"intercept and the ARK 224-block settlement-timing mechanics.")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 12*time.Minute)
+	defer cancel()
+
+	client, err := newFulmineClient(clientFulmineURL)
+	require.NoError(t, err)
+	defer startBoltzAndWait(t)
+
+	btcAddress := nigiriGetNewAddress(t, ctx)
+	createResp, err := client.CreateChainSwap(ctx, &pb.CreateChainSwapRequest{
+		Direction:  pb.SwapDirection_SWAP_DIRECTION_ARK_TO_BTC,
+		Amount:     3000,
+		BtcAddress: btcAddress,
+	})
+	require.NoError(t, err)
+	require.Empty(t, createResp.GetError())
+	swapID := createResp.GetId()
+	require.NotEmpty(t, swapID)
+
+	bal, _ := client.GetBalance(ctx, &pb.GetBalanceRequest{})
+	t.Logf("ARK balance before swap: %d; createResp=%+v", bal.GetAmount(), createResp)
+
+	// Pause Boltz immediately — docker pause is instant (unlike stop's graceful
+	// shutdown), racing to freeze it before it sees the ARK VHTLC and completes
+	// the swap (which it does in <1s here).
+	_, _ = runCommand(ctx, "docker pause boltz")
+	defer func() { _, _ = runCommand(context.Background(), "docker unpause boltz") }()
+
+	// Wait for fulmine to lock the ARK VHTLC (user_locked).
+	start := time.Now()
+	var last string
+	locked := false
+	winDeadline := time.Now().Add(120 * time.Second)
+	for time.Now().Before(winDeadline) && !locked {
+		resp, e := client.ListChainSwaps(ctx, &pb.ListChainSwapsRequest{SwapIds: []string{swapID}})
+		if e == nil && len(resp.GetSwaps()) > 0 {
+			sw := resp.GetSwaps()[0]
+			s := sw.GetStatus()
+			if s != last {
+				t.Logf("STATUS t+%.1fs: %s  swap=%+v", time.Since(start).Seconds(), s, sw)
+				last = s
+			}
+			switch s {
+			case "user_locked":
+				locked = true
+			case "claimed":
+				t.Fatalf("swap completed despite Boltz stopped (status=%s) at t+%.1fs", s, time.Since(start).Seconds())
+			}
+		}
+		time.Sleep(2 * time.Second)
+	}
+	require.True(t, locked, "fulmine never locked the ARK VHTLC with Boltz down (last=%s)", last)
+
+	// The without-receiver locktime (224 blocks) is RELATIVE to the VTXO's
+	// confirmation, and the ARK VHTLC only confirms after a (time-based) arkd
+	// round commits it on-chain. Wait for the round, then burst-mine to confirm
+	// the commitment AND clear the 224-block locktime from there.
+	time.Sleep(60 * time.Second)
+	mineRegtestBlocks(t, ctx, 320)
+
+	// Drive the refund. Background miner feeds confirmation blocks + a long
+	// per-call budget as in the BTC->ARK case.
+	mineCtx, stopMiner := context.WithCancel(ctx)
+	defer stopMiner()
+	go func() {
+		for {
+			select {
+			case <-mineCtx.Done():
+				return
+			case <-time.After(3 * time.Second):
+				_, _ = regtestCmd(mineCtx, "mine", "1")
+			}
+		}
+	}()
+
+	refDeadline := time.Now().Add(4 * time.Minute)
+	for {
+		cctx, cancelC := context.WithTimeout(ctx, 3*time.Minute)
+		_, e := client.RefundChainSwap(cctx, &pb.RefundChainSwapRequest{Id: swapID})
+		cancelC()
+		if e == nil {
+			break
+		}
+		msg := stripANSI(e.Error())
+		t.Logf("refund attempt error: %s", msg)
+		require.Truef(t, time.Now().Before(refDeadline), "ARK->BTC unilateral refund failed: %s", msg)
+		time.Sleep(3 * time.Second)
+	}
+	waitChainSwapStatus(t, ctx, client, swapID, "refunded_unilaterally", 4*time.Minute)
+}
 
 func TestChainSwapRefundChainSwapRPC(t *testing.T) {
 	t.Run("ark_to_btc_cooperative", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Restores e2e coverage of the **unilateral chain-swap refund** fund-safety paths that were lost when #422 removed the in-repo mock-Boltz fault injection. Instead of a mock knob, this drives the **real Boltz container** — the approach the dotnet-sdk e2e suite uses (`NArk.Tests.End2End/Common/DockerHelper`).

**Stacked on #422** (needs the arkade-regtest stack).

## What's covered

### `TestChainSwapBTCToARKUnilateralRefund` — passing, CI-safe ✅

The unilateral BTC refund: the user locks BTC but Boltz never claims it, so after the lockup's CLTV the user reclaims it on-chain.

The key is a **race-free intercept**: fund the lockup *without confirming it*, so Boltz reports the mempool lockup (fulmine records the txid) but won't lock the ARK side until it confirms. Stop Boltz in that window, then confirm — only the unilateral path remains. Then burst past the CLTV and drive the synchronous refund (background miner + long per-call budget).

Verified its Boltz stop/restart **doesn't disrupt** the cooperative-refund and recovery tests that run after it in the suite.

### `TestChainSwapArkToBTCUnilateralRefund` — skipped, documented ⏭️

The ARK→BTC direction **auto-completes in <1s** with no unconfirmed-lockup hold point. `docker pause` can freeze Boltz at `user_locked`, but the race is flaky (proven: one run froze in time, the next lost to Boltz locking the BTC side first). A flaky interception can't be a reliable e2e test, so it's skipped with the finding documented; the code is kept as a reference for the pause-intercept and the ARK 224-block settlement-timing mechanics. **This fund-safety path belongs in a `pkg/swap` unit test** (tracked in #425).

## Test plan

- [x] `TestChainSwapBTCToARKUnilateralRefund` passes locally — 2× solo + in-suite alongside the cooperative-refund and recovery tests
- [x] `go vet` + `gofmt` clean
- [ ] CI on the arkade-regtest stack (runs once #422 lands / this rebases)
