### PR TITLE
test(swap): cover ARK→BTC unilateral refund + fix pkg/swap build & CI gating

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,11 @@ run-mutinynet: clean build-static-assets
 test:
 	@echo "Running all tests..."
 	@go test -v -race --count=1 $(shell go list ./... | grep -v *internal/test/e2e*)
-	@find ./pkg -name go.mod -execdir go test -v ./... \;
+	@for gomod in $$(find ./pkg -name go.mod); do \
+		moddir=$$(dirname $$gomod); \
+		echo "Testing module $$moddir..."; \
+		(cd $$moddir && go test -v ./...) || exit 1; \
+	done
 
 ## vet: code analysis
 vet:

--- a/pkg/swap/go.mod
+++ b/pkg/swap/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
 	github.com/arkade-os/arkd/api-spec v0.0.0-20260323091657-eeb0baef6937 // indirect
-	github.com/arkade-os/arkd/pkg/errors v0.0.0-20260303153651-8615412e4dea // indirect
+	github.com/arkade-os/arkd/pkg/errors v0.0.0-20260613161613-a667da8c7dfd // indirect
 	github.com/btcsuite/btclog/v2 v2.0.1-0.20250602222548-9967d19bb084 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dgraph-io/badger/v4 v4.8.0 // indirect

--- a/pkg/swap/go.sum
+++ b/pkg/swap/go.sum
@@ -24,6 +24,8 @@ github.com/arkade-os/arkd/pkg/client-lib v0.0.0-20260615145327-0a5e6eb511e2 h1:s
 github.com/arkade-os/arkd/pkg/client-lib v0.0.0-20260615145327-0a5e6eb511e2/go.mod h1:TCvgTjNjKeX0VW2h1+YoN+EFxT/yY+dRxmD96OV1dRw=
 github.com/arkade-os/arkd/pkg/errors v0.0.0-20260303153651-8615412e4dea h1:x9ZwZL+F2b9E0uBZYBVjCLGtlqIE4zahDOY4C89h3X4=
 github.com/arkade-os/arkd/pkg/errors v0.0.0-20260303153651-8615412e4dea/go.mod h1:NYGE+baj57ynbXNwjISJddMDpMqAWOX27dV22xqFm2A=
+github.com/arkade-os/arkd/pkg/errors v0.0.0-20260613161613-a667da8c7dfd h1:+DPvjarSstAfJ3i3zV5Xg9nSVIfQ4K4D9jdr7vCXqSE=
+github.com/arkade-os/arkd/pkg/errors v0.0.0-20260613161613-a667da8c7dfd/go.mod h1:RNO1HZeCLI3oDKF1NhlMQLRHIqXJ8S4GyVT8EAanQU8=
 github.com/arkade-os/go-sdk v0.9.2-0.20260615205532-87bf561185ff h1:rA2n/HhX8QV3dRJleVLPVWPfRYs2t/6B2woOIBJ6T5E=
 github.com/arkade-os/go-sdk v0.9.2-0.20260615205532-87bf561185ff/go.mod h1:tP+DiJ5kLxi3CfbY8YnWAxfNlRnAlnmjJMcNWJXHx78=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=

--- a/pkg/swap/unilateral_refund_test.go
+++ b/pkg/swap/unilateral_refund_test.go
@@ -1,0 +1,107 @@
+package swap
+
+import (
+	"crypto/sha256"
+	"testing"
+
+	"github.com/ArkLabsHQ/fulmine/pkg/vhtlc"
+	arklib "github.com/arkade-os/arkd/pkg/ark-lib"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestVHTLCScript builds a VHTLC script with throwaway test keys, enough to
+// exercise the refund-path selection and locktime/sequence logic without any
+// live arkd/Boltz state. The specific keys don't matter for these assertions —
+// only the closure shapes do.
+func newTestVHTLCScript(t *testing.T, refundLocktime arklib.AbsoluteLocktime) *vhtlc.VHTLCScript {
+	t.Helper()
+
+	pubKey := func() *btcec.PublicKey {
+		k, err := btcec.NewPrivateKey()
+		require.NoError(t, err)
+		return k.PubKey()
+	}
+
+	// VHTLC preimage hashes are RIPEMD160(SHA256(preimage)); a fixed preimage
+	// keeps the fixture deterministic.
+	sha := sha256.Sum256([]byte("fulmine-unilateral-refund-test"))
+	preimageHash := input.Ripemd160H(sha[:])
+
+	vhtlcScript, err := vhtlc.NewVHTLCScriptFromOpts(vhtlc.Opts{
+		Sender:                               pubKey(),
+		Receiver:                             pubKey(),
+		Server:                               pubKey(),
+		PreimageHash:                         preimageHash,
+		RefundLocktime:                       refundLocktime,
+		UnilateralClaimDelay:                 arklib.RelativeLocktime{Type: arklib.LocktimeTypeBlock, Value: 144},
+		UnilateralRefundDelay:                arklib.RelativeLocktime{Type: arklib.LocktimeTypeBlock, Value: 72},
+		UnilateralRefundWithoutReceiverDelay: arklib.RelativeLocktime{Type: arklib.LocktimeTypeBlock, Value: 224},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, vhtlcScript.RefundClosure)
+	require.NotNil(t, vhtlcScript.RefundWithoutReceiverClosure)
+	return vhtlcScript
+}
+
+// TestRefundForfeitTxBuilderSigningClosure pins the fund-safety-critical refund
+// path selection for ARK→BTC chain swaps.
+//
+// When Boltz (the receiver) refuses to cooperate, the refund must spend the
+// without-receiver closure (Sender+Server, CLTV-gated). Spending the
+// cooperative RefundClosure (which also needs the receiver's signature) would
+// be impossible without Boltz and the user's funds would be stuck — so a
+// swapped condition here is a fund-loss bug, not a cosmetic one.
+func TestRefundForfeitTxBuilderSigningClosure(t *testing.T) {
+	vhtlcScript := newTestVHTLCScript(t, arklib.AbsoluteLocktime(2_000_000_000))
+
+	t.Run("without receiver selects the without-receiver closure", func(t *testing.T) {
+		builder := &refundForfeitTxBuilder{withReceiver: false}
+
+		got := builder.getSigningClosure(vhtlcScript)
+
+		require.Same(t, vhtlcScript.RefundWithoutReceiverClosure, got)
+		require.NotSame(t, vhtlcScript.RefundClosure, got)
+	})
+
+	t.Run("with receiver selects the cooperative closure", func(t *testing.T) {
+		builder := &refundForfeitTxBuilder{withReceiver: true}
+
+		got := builder.getSigningClosure(vhtlcScript)
+
+		require.Same(t, vhtlcScript.RefundClosure, got)
+		require.NotSame(t, vhtlcScript.RefundWithoutReceiverClosure, got)
+	})
+}
+
+// TestExtractLocktimeAndSequenceRefundPaths pins the consensus-level gating of
+// the refund transaction's VTXO input.
+//
+// The without-receiver refund is gated by an absolute CLTV locktime, so its
+// input sequence must be < 0xFFFFFFFF (here MaxTxInSequenceNum-1) for the
+// timelock to be enforced by consensus. Returning MaxTxInSequenceNum would
+// silently disable the timelock. The cooperative refund has no timelock, so it
+// uses the final sequence and a zero locktime.
+func TestExtractLocktimeAndSequenceRefundPaths(t *testing.T) {
+	vhtlcScript := newTestVHTLCScript(t, arklib.AbsoluteLocktime(2_000_000_000))
+
+	t.Run("without-receiver (CLTV) closure enables the timelock", func(t *testing.T) {
+		locktime, sequence := extractLocktimeAndSequence(vhtlcScript.RefundWithoutReceiverClosure)
+
+		// extract the closure's own absolute locktime...
+		require.Equal(t, vhtlcScript.RefundWithoutReceiverClosure.Locktime, locktime)
+		// ...and it must be a real, non-zero timelock...
+		require.NotZero(t, locktime)
+		// ...with a sequence that actually enables nLockTime enforcement.
+		require.Equal(t, uint32(wire.MaxTxInSequenceNum-1), sequence)
+	})
+
+	t.Run("cooperative (non-CLTV) closure has no timelock", func(t *testing.T) {
+		locktime, sequence := extractLocktimeAndSequence(vhtlcScript.RefundClosure)
+
+		require.Equal(t, arklib.AbsoluteLocktime(0), locktime)
+		require.Equal(t, uint32(wire.MaxTxInSequenceNum), sequence)
+	})
+}


### PR DESCRIPTION
## Summary

Adds unit coverage for the **ARK→BTC unilateral chain-swap refund** — the one fund-safety path that isn't reliably e2e-testable (the swap auto-completes in <1s with no hold point; see #425 and #426). Fixing it surfaced, and this PR also fixes, two latent infra issues: **`pkg/swap` didn't build standalone**, and **`ci.unit` never actually enforced pkg-module tests**.

Addresses #425 (the refund-path selection + gating; the full tx-assembly/signing path stays integration-heavy and is not covered here).

## 1. The fund-safety tests (`pkg/swap/unilateral_refund_test.go`)

Two invariants that strand user funds if broken — and that `vhtlc_test.go` doesn't cover (it asserts the closures are *built*, not which is *selected* or *how it's gated*):

1. **Refund-path selection** (`getSigningClosure`): when Boltz (the receiver) won't cooperate, the refund must spend the **without-receiver** closure (Sender+Server, CLTV). Selecting the cooperative `RefundClosure` — which also needs the receiver's signature — would make the refund permanently unspendable once Boltz is gone.
2. **Consensus-level gating** (`extractLocktimeAndSequence`): the CLTV refund input must carry sequence `MaxTxInSequenceNum-1`, or the absolute timelock is silently *not enforced* by consensus.

Verified non-vacuous by mutation: swapping the `getSigningClosure` condition makes the test fail — it catches the cooperative `MultisigClosure{3 keys}` being returned where the without-receiver `CLTVMultisigClosure{2 keys}` is required.

## 2. The build fix (`pkg/swap/go.mod`, one line)

`pkg/swap`'s `arkd/pkg/errors` pin was stale (`20260303`, March) while its own `client-lib` pin (`20260615`, June) references `errors.DIGEST_MISMATCH` — a constant the older `errors` module lacks. So `pkg/swap` did not compile standalone. The root module masked this: it pins a newer `errors` and builds `pkg/swap` via `replace` for the e2e suite. Bumped the pin to the version the root already uses (`20260613`); the e2e build proves `pkg/swap`'s code is compatible with it.

## 3. The CI enforcement fix (`Makefile`)

This is *why* the standalone break went unnoticed. `make test` ran pkg-module tests via:

```
find ./pkg -name go.mod -execdir go test -v ./... \;
```

`find`'s exit status reflects only `find`'s own errors, **not** the exit codes of `-execdir` commands (verified: `find ./pkg -name go.mod -execdir false \;` returns `0`). So any pkg-module build/test failure was swallowed and `ci.unit` stayed green regardless. Replaced with a loop that propagates the first failure, so these new tests (and all pkg-module tests) now actually gate CI.

This is bundled here deliberately: it depends on fix #2 being in the same PR — enforcing pkg-module tests *without* the build fix would (correctly) turn `ci.unit` red, since `pkg/swap` doesn't build standalone on `master`.

## Test plan

- [x] `cd pkg/swap && go test ./...` — green (new tests + existing `bolt12_test`)
- [x] Mutation check: swapped `getSigningClosure` condition → tests fail; reverted → pass
- [x] `gofmt` + `go vet` clean
- [x] All pkg modules (`boltz`, `swap`, `vhtlc`) build and test standalone after the build fix
- [x] Makefile loop verified: exit 0 with all modules green; a failing module exits non-zero (where `find` returned 0)
