### PR TITLE
test(swap): fund-safety unit coverage for the BTC→ARK unilateral refund

### DIFF
--- a/pkg/swap/chainswap_refund_test.go
+++ b/pkg/swap/chainswap_refund_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ArkLabsHQ/fulmine/pkg/boltz"
 	arklib "github.com/arkade-os/arkd/pkg/ark-lib"
 	clientTypes "github.com/arkade-os/arkd/pkg/client-lib/types"
+	arksdk "github.com/arkade-os/go-sdk"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil"
@@ -23,19 +24,21 @@ import (
 // Only GetTransaction and GetCurrentBlockHeight are reached before the CLTV
 // gate; the rest are unreached stubs.
 type refundMockExplorer struct {
-	txHex  string
-	height uint32
-	txErr  error
+	txHex         string
+	height        uint32
+	txErr         error
+	broadcastTxid string
 }
 
 func (m *refundMockExplorer) GetTransaction(string) (string, error)  { return m.txHex, m.txErr }
 func (m *refundMockExplorer) GetCurrentBlockHeight() (uint32, error) { return m.height, nil }
 func (m *refundMockExplorer) BroadcastTransaction(*wire.MsgTx) (string, error) {
-	return "", nil
+	return m.broadcastTxid, nil
 }
 func (m *refundMockExplorer) GetFeeRate() (float64, error) { return 1, nil }
 func (m *refundMockExplorer) GetTransactionStatus(string) (*TransactionStatus, error) {
-	return nil, nil
+	// confirmed, so RefundBtcToArkSwap's post-broadcast wait loop exits at once.
+	return &TransactionStatus{Confirmed: true}, nil
 }
 
 // buildLockupFixture synthesizes a regtest taproot lockup output and the Boltz
@@ -64,13 +67,20 @@ func buildLockupFixture(t *testing.T, timeout int64) (lockupTxHex, swapRespJSON 
 	var buf bytes.Buffer
 	require.NoError(t, lockupTx.Serialize(&buf))
 
+	serverKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
 	resp := boltz.CreateChainSwapResponse{
 		LockupDetails: boltz.SwapLeg{
-			LockupAddress: addr.String(),
+			LockupAddress:   addr.String(),
+			ServerPublicKey: hex.EncodeToString(serverKey.PubKey().SerializeCompressed()),
 			SwapTree: &boltz.SwapTree{
-				RefundLeaf: boltz.SwapTreeLeaf{
-					Output: buildRefundLeafScript(t, testRefundXOnlyPubKey(t), timeout),
-				},
+				// A distinct claim leaf so the swap tree is a real 2-leaf merkle
+				// tree — createControlBlockFromSwapTree uses it as the refund
+				// path's sibling hash. Its content is irrelevant (only hashed);
+				// timeout+1 just keeps it distinct from the refund leaf.
+				ClaimLeaf:  boltz.SwapTreeLeaf{Version: 0xc0, Output: buildRefundLeafScript(t, testRefundXOnlyPubKey(t), timeout+1)},
+				RefundLeaf: boltz.SwapTreeLeaf{Version: 0xc0, Output: buildRefundLeafScript(t, testRefundXOnlyPubKey(t), timeout)},
 			},
 		},
 	}
@@ -125,4 +135,66 @@ func TestRefundBtcToArkSwapGuards(t *testing.T) {
 
 		require.ErrorContains(t, err, "CLTV timeout not yet reached")
 	})
+}
+
+// refundMockArkClient is a fake arksdk.ArkClient for the post-gate refund flow.
+// It embeds the interface (so any unexpected call panics) and overrides the two
+// ArkClient calls RefundBtcToArkSwap makes: NewBoardingAddress (the destination
+// for the reclaimed BTC) and Settle (boarding that BTC as a VTXO).
+type refundMockArkClient struct {
+	arksdk.ArkClient
+	boardingAddr string
+}
+
+func (m *refundMockArkClient) NewBoardingAddress(context.Context) (string, error) {
+	return m.boardingAddr, nil
+}
+
+func (m *refundMockArkClient) Settle(context.Context, ...arksdk.BatchSessionOption) (string, error) {
+	return "settle-txid", nil
+}
+
+// TestRefundBtcToArkSwapBroadcastsPastGate covers the fund-recovery payoff once
+// the CLTV gate opens: RefundBtcToArkSwap must construct the refund tx, sign the
+// taproot refund leaf, and broadcast it to move the locked BTC to the user's
+// boarding address. The cooperative e2e never reaches a unilateral refund, so
+// this drives it with synthesized swap crypto + a mocked explorer/ArkClient. It
+// asserts the broadcast txid is returned (the funds left the lockup), proving
+// the whole build->sign->broadcast path ran, not just that the gate opened.
+func TestRefundBtcToArkSwapBroadcastsPastGate(t *testing.T) {
+	const timeout = 800_000
+	lockupHex, respJSON := buildLockupFixture(t, timeout)
+
+	// constructClaimTransaction hex-decodes the lockup txid into the claim tx's
+	// input outpoint, and the taproot prevout fetcher matches on it, so derive the
+	// real txid from the fixture rather than passing a placeholder.
+	raw, err := hex.DecodeString(lockupHex)
+	require.NoError(t, err)
+	var lockupTx wire.MsgTx
+	require.NoError(t, lockupTx.Deserialize(bytes.NewReader(raw)))
+	lockupTxid := lockupTx.TxHash().String()
+
+	userKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	// a valid regtest taproot address for the refund destination
+	destKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	boardingAddr, err := btcutil.NewAddressTaproot(schnorr.SerializePubKey(destKey.PubKey()), &chaincfg.RegressionNetParams)
+	require.NoError(t, err)
+
+	h := &SwapHandler{
+		explorerClient: &refundMockExplorer{
+			txHex:         lockupHex,
+			height:        timeout, // gate opens: currentHeight >= timeout
+			broadcastTxid: "refund-broadcast-txid",
+		},
+		arkClient:  &refundMockArkClient{boardingAddr: boardingAddr.String()},
+		privateKey: userKey,
+		config:     clientTypes.Config{Network: arklib.BitcoinRegTest},
+	}
+
+	txid, err := h.RefundBtcToArkSwap(context.Background(), "swap", 1000, lockupTxid, respJSON)
+	require.NoError(t, err)
+	require.Equal(t, "refund-broadcast-txid", txid)
 }

--- a/pkg/swap/chainswap_refund_test.go
+++ b/pkg/swap/chainswap_refund_test.go
@@ -1,0 +1,128 @@
+package swap
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+
+	"github.com/ArkLabsHQ/fulmine/pkg/boltz"
+	arklib "github.com/arkade-os/arkd/pkg/ark-lib"
+	clientTypes "github.com/arkade-os/arkd/pkg/client-lib/types"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/stretchr/testify/require"
+)
+
+// refundMockExplorer is a minimal ExplorerClient for the BTC→ARK refund guards.
+// Only GetTransaction and GetCurrentBlockHeight are reached before the CLTV
+// gate; the rest are unreached stubs.
+type refundMockExplorer struct {
+	txHex  string
+	height uint32
+	txErr  error
+}
+
+func (m *refundMockExplorer) GetTransaction(string) (string, error)  { return m.txHex, m.txErr }
+func (m *refundMockExplorer) GetCurrentBlockHeight() (uint32, error) { return m.height, nil }
+func (m *refundMockExplorer) BroadcastTransaction(*wire.MsgTx) (string, error) {
+	return "", nil
+}
+func (m *refundMockExplorer) GetFeeRate() (float64, error) { return 1, nil }
+func (m *refundMockExplorer) GetTransactionStatus(string) (*TransactionStatus, error) {
+	return nil, nil
+}
+
+// buildLockupFixture synthesizes a regtest taproot lockup output and the Boltz
+// chain-swap response that references it, with a refund leaf carrying the given
+// absolute CLTV block height. The lockup tx pays the swap's lockup address, so
+// findOutputForAddress resolves it — enough to drive RefundBtcToArkSwap through
+// deserialization, output lookup and refund-leaf parsing up to the CLTV gate,
+// with no live Boltz or regtest state. payToAddrScript is the package's own, so
+// the synthesized output matches what findOutputForAddress derives.
+func buildLockupFixture(t *testing.T, timeout int64) (lockupTxHex, swapRespJSON string) {
+	t.Helper()
+
+	k, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	addr, err := btcutil.NewAddressTaproot(schnorr.SerializePubKey(k.PubKey()), &chaincfg.RegressionNetParams)
+	require.NoError(t, err)
+	pkScript, err := payToAddrScript(addr)
+	require.NoError(t, err)
+
+	lockupTx := wire.NewMsgTx(2)
+	// a real lockup tx is funded; give it one input so the zero-input SegWit
+	// serialization ambiguity (a 0x00 input count read as the witness marker)
+	// doesn't bite on deserialize round-trip.
+	lockupTx.AddTxIn(wire.NewTxIn(wire.NewOutPoint(&chainhash.Hash{}, 0), nil, nil))
+	lockupTx.AddTxOut(wire.NewTxOut(100_000, pkScript))
+	var buf bytes.Buffer
+	require.NoError(t, lockupTx.Serialize(&buf))
+
+	resp := boltz.CreateChainSwapResponse{
+		LockupDetails: boltz.SwapLeg{
+			LockupAddress: addr.String(),
+			SwapTree: &boltz.SwapTree{
+				RefundLeaf: boltz.SwapTreeLeaf{
+					Output: buildRefundLeafScript(t, testRefundXOnlyPubKey(t), timeout),
+				},
+			},
+		},
+	}
+	respJSON, err := json.Marshal(resp)
+	require.NoError(t, err)
+
+	return hex.EncodeToString(buf.Bytes()), string(respJSON)
+}
+
+func newRefundTestHandler(exp ExplorerClient) *SwapHandler {
+	return &SwapHandler{
+		explorerClient: exp,
+		config:         clientTypes.Config{Network: arklib.BitcoinRegTest},
+	}
+}
+
+// TestRefundBtcToArkSwapGuards pins the input-validation and CLTV-gate guards of
+// the BTC→ARK unilateral refund — the path a user takes to reclaim BTC when Boltz
+// goes down mid-swap. The CLTV gate is the fund-safety crux: broadcasting a
+// refund before its absolute timelock is consensus-invalid (fees burned on a
+// doomed tx), while a gate that never opened would strand the funds. All these
+// guards sit before any ArkClient call, so they run with only a mocked explorer.
+func TestRefundBtcToArkSwapGuards(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("rejects an empty lockup txid", func(t *testing.T) {
+		_, err := newRefundTestHandler(&refundMockExplorer{}).
+			RefundBtcToArkSwap(ctx, "swap", 1000, "", "{}")
+		require.ErrorContains(t, err, "userLockupTxid empty")
+	})
+
+	t.Run("rejects an empty swap response", func(t *testing.T) {
+		_, err := newRefundTestHandler(&refundMockExplorer{}).
+			RefundBtcToArkSwap(ctx, "swap", 1000, "lockuptxid", "")
+		require.ErrorContains(t, err, "boltzSwapRespJson empty")
+	})
+
+	t.Run("rejects a malformed swap response", func(t *testing.T) {
+		lockupHex, _ := buildLockupFixture(t, 800_000)
+		_, err := newRefundTestHandler(&refundMockExplorer{txHex: lockupHex}).
+			RefundBtcToArkSwap(ctx, "swap", 1000, "lockuptxid", "{not-json")
+		require.Error(t, err)
+	})
+
+	t.Run("rejects when the CLTV timeout has not been reached", func(t *testing.T) {
+		const timeout = 800_000
+		lockupHex, respJSON := buildLockupFixture(t, timeout)
+		exp := &refundMockExplorer{txHex: lockupHex, height: timeout - 1}
+
+		_, err := newRefundTestHandler(exp).
+			RefundBtcToArkSwap(ctx, "swap", 1000, "lockuptxid", respJSON)
+
+		require.ErrorContains(t, err, "CLTV timeout not yet reached")
+	})
+}

--- a/pkg/swap/chainswap_refund_test.go
+++ b/pkg/swap/chainswap_refund_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/ArkLabsHQ/fulmine/pkg/boltz"
@@ -136,6 +137,15 @@ func TestRefundBtcToArkSwapGuards(t *testing.T) {
 			RefundBtcToArkSwap(ctx, "swap", 1000, "lockuptxid", respJSON)
 
 		require.ErrorContains(t, err, "CLTV timeout not yet reached")
+	})
+
+	t.Run("propagates an explorer GetTransaction error", func(t *testing.T) {
+		// the lockup tx fetch is the first explorer call; a failure there must
+		// surface rather than be swallowed into an empty lockup tx.
+		exp := &refundMockExplorer{txErr: errors.New("explorer unreachable")}
+		_, err := newRefundTestHandler(exp).
+			RefundBtcToArkSwap(ctx, "swap", 1000, "lockuptxid", "{}")
+		require.ErrorContains(t, err, "failed to fetch lockup transaction")
 	})
 }
 

--- a/pkg/swap/chainswap_refund_test.go
+++ b/pkg/swap/chainswap_refund_test.go
@@ -28,11 +28,13 @@ type refundMockExplorer struct {
 	height        uint32
 	txErr         error
 	broadcastTxid string
+	broadcastTx   *wire.MsgTx // captured so tests can assert the refund tx's fields
 }
 
 func (m *refundMockExplorer) GetTransaction(string) (string, error)  { return m.txHex, m.txErr }
 func (m *refundMockExplorer) GetCurrentBlockHeight() (uint32, error) { return m.height, nil }
-func (m *refundMockExplorer) BroadcastTransaction(*wire.MsgTx) (string, error) {
+func (m *refundMockExplorer) BroadcastTransaction(tx *wire.MsgTx) (string, error) {
+	m.broadcastTx = tx
 	return m.broadcastTxid, nil
 }
 func (m *refundMockExplorer) GetFeeRate() (float64, error) { return 1, nil }
@@ -183,18 +185,28 @@ func TestRefundBtcToArkSwapBroadcastsPastGate(t *testing.T) {
 	boardingAddr, err := btcutil.NewAddressTaproot(schnorr.SerializePubKey(destKey.PubKey()), &chaincfg.RegressionNetParams)
 	require.NoError(t, err)
 
+	exp := &refundMockExplorer{
+		txHex:         lockupHex,
+		height:        timeout, // gate opens: currentHeight >= timeout
+		broadcastTxid: "refund-broadcast-txid",
+	}
 	h := &SwapHandler{
-		explorerClient: &refundMockExplorer{
-			txHex:         lockupHex,
-			height:        timeout, // gate opens: currentHeight >= timeout
-			broadcastTxid: "refund-broadcast-txid",
-		},
-		arkClient:  &refundMockArkClient{boardingAddr: boardingAddr.String()},
-		privateKey: userKey,
-		config:     clientTypes.Config{Network: arklib.BitcoinRegTest},
+		explorerClient: exp,
+		arkClient:      &refundMockArkClient{boardingAddr: boardingAddr.String()},
+		privateKey:     userKey,
+		config:         clientTypes.Config{Network: arklib.BitcoinRegTest},
 	}
 
 	txid, err := h.RefundBtcToArkSwap(context.Background(), "swap", 1000, lockupTxid, respJSON)
 	require.NoError(t, err)
 	require.Equal(t, "refund-broadcast-txid", txid)
+
+	// Pin the consensus-critical fields of the broadcast refund tx. Without these
+	// the test would stay green even if the CLTV locktime, the non-final input
+	// sequence, or the taproot witness were dropped — each unspendable on a real
+	// node, but invisible to a mock that only hands back a canned txid.
+	require.NotNil(t, exp.broadcastTx)
+	require.Equal(t, uint32(timeout), exp.broadcastTx.LockTime, "refund tx must carry the CLTV locktime")
+	require.Equal(t, wire.MaxTxInSequenceNum-1, exp.broadcastTx.TxIn[0].Sequence, "input must be non-final for CLTV")
+	require.Len(t, exp.broadcastTx.TxIn[0].Witness, 3, "tapscript refund witness: [signature, refundScript, controlBlock]")
 }

--- a/pkg/swap/chainswap_validate_test.go
+++ b/pkg/swap/chainswap_validate_test.go
@@ -122,4 +122,20 @@ func TestValidateRefundLeafScript(t *testing.T) {
 		_, err = ValidateRefundLeafScript(hex.EncodeToString(append(valid, 0xde, 0xad)))
 		require.Error(t, err)
 	})
+
+	t.Run("rejects a timeout push longer than 4 bytes", func(t *testing.T) {
+		// The parser bounds the timeout push at 1-4 bytes (a uint32 height never
+		// needs more). Feed a 5-byte push to pin the upper bound — the leaf is 41
+		// bytes, clearing the 38-byte floor, so the push-length check is what
+		// rejects it, not the length guard.
+		pubKey := testRefundXOnlyPubKey(t)
+		var b []byte
+		b = append(b, 0x20)
+		b = append(b, pubKey[:]...)
+		b = append(b, txscript.OP_CHECKSIGVERIFY)
+		b = append(b, 0x05, 0x01, 0x02, 0x03, 0x04, 0x05) // 5-byte timeout push (> 4)
+		b = append(b, txscript.OP_CHECKLOCKTIMEVERIFY)
+		_, err := ValidateRefundLeafScript(hex.EncodeToString(b))
+		require.ErrorContains(t, err, "push length")
+	})
 }

--- a/pkg/swap/chainswap_validate_test.go
+++ b/pkg/swap/chainswap_validate_test.go
@@ -1,0 +1,125 @@
+package swap
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/stretchr/testify/require"
+)
+
+// buildRefundLeafScript synthesizes a Boltz-format refund-leaf taproot script in
+// exactly the layout parseRefundHTLCScriptManually expects:
+//
+//	<32-byte x-only refund pubkey> OP_CHECKSIGVERIFY <timeout> OP_CHECKLOCKTIMEVERIFY
+//
+// It mirrors what Boltz emits in the chain-swap tree's RefundLeaf, so the parser
+// can be pinned without any live Boltz or regtest state.
+func buildRefundLeafScript(t *testing.T, refundPubKey [32]byte, timeout int64) string {
+	t.Helper()
+	script, err := txscript.NewScriptBuilder().
+		AddData(refundPubKey[:]).
+		AddOp(txscript.OP_CHECKSIGVERIFY).
+		AddInt64(timeout).
+		AddOp(txscript.OP_CHECKLOCKTIMEVERIFY).
+		Script()
+	require.NoError(t, err)
+	return hex.EncodeToString(script)
+}
+
+func testRefundXOnlyPubKey(t *testing.T) [32]byte {
+	t.Helper()
+	k, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	var xonly [32]byte
+	copy(xonly[:], schnorr.SerializePubKey(k.PubKey()))
+	return xonly
+}
+
+// TestValidateRefundLeafScript pins the parse of the Boltz refund leaf, the
+// fund-safety-critical step that feeds the BTC→ARK unilateral refund's CLTV gate
+// (SwapHandler.RefundBtcToArkSwap). A misparsed timeout would let the refund
+// broadcast before its timelock (consensus-rejected) or block one already
+// reached; a misparsed pubkey yields an unspendable refund. Both strand user
+// funds, so this is a fund-loss guard, not a cosmetic check.
+//
+// This covers the parse in isolation; the surrounding
+// fetch→gate→build→sign→broadcast flow still needs a mocked
+// ArkClient/ExplorerClient harness (tracked in #425).
+func TestValidateRefundLeafScript(t *testing.T) {
+	t.Run("valid script round-trips timeout and pubkey", func(t *testing.T) {
+		// Boltz refund timeouts are absolute block heights, encoded as a
+		// little-endian data push. These values exercise the parser's decode
+		// across 2- and 3-byte pushes (the sub-128 / 1-byte case is covered
+		// separately below).
+		for _, timeout := range []int64{128, 144, 500, 70_000, 1_000_000} {
+			pubKey := testRefundXOnlyPubKey(t)
+
+			components, err := ValidateRefundLeafScript(buildRefundLeafScript(t, pubKey, timeout))
+
+			require.NoError(t, err, "timeout %d", timeout)
+			require.NotNil(t, components)
+			require.Equal(t, uint32(timeout), components.Timeout, "timeout %d", timeout)
+			require.Equal(t, pubKey, components.RefundPubKey, "timeout %d", timeout)
+		}
+	})
+
+	t.Run("a sub-128 timeout falls below the 38-byte floor and is rejected", func(t *testing.T) {
+		// A real parser edge surfaced while writing this test: a timeout < 128
+		// encodes to a single byte, making the leaf 37 bytes, which trips
+		// parseRefundHTLCScriptManually's hard-coded 38-byte minimum. Boltz CLTV
+		// timeouts are absolute block heights (current height + timeout blocks)
+		// and clear 128 in practice, so this isn't reachable today — but if it
+		// ever were, the refund leaf wouldn't parse and the unilateral refund
+		// would fail. Pinned so a parser change (e.g. a real minimal-length
+		// check) surfaces the behavior shift. See #425.
+		pubKey := testRefundXOnlyPubKey(t)
+		_, err := ValidateRefundLeafScript(buildRefundLeafScript(t, pubKey, 100))
+		require.ErrorContains(t, err, "too short")
+	})
+
+	t.Run("rejects non-hex input", func(t *testing.T) {
+		_, err := ValidateRefundLeafScript("nothex!!")
+		require.Error(t, err)
+	})
+
+	t.Run("rejects a script below the 38-byte minimum", func(t *testing.T) {
+		_, err := ValidateRefundLeafScript(hex.EncodeToString([]byte{0x20, 0x01, 0x02}))
+		require.Error(t, err)
+	})
+
+	t.Run("rejects a wrong signature opcode", func(t *testing.T) {
+		// well-formed length, but OP_NOP where OP_CHECKSIGVERIFY must be.
+		pubKey := testRefundXOnlyPubKey(t)
+		var b []byte
+		b = append(b, 0x20)
+		b = append(b, pubKey[:]...)
+		b = append(b, txscript.OP_NOP)
+		b = append(b, 0x02, 0x90, 0x00) // 2-byte timeout push (144)
+		b = append(b, txscript.OP_CHECKLOCKTIMEVERIFY)
+		_, err := ValidateRefundLeafScript(hex.EncodeToString(b))
+		require.Error(t, err)
+	})
+
+	t.Run("rejects a missing OP_CHECKLOCKTIMEVERIFY", func(t *testing.T) {
+		pubKey := testRefundXOnlyPubKey(t)
+		var b []byte
+		b = append(b, 0x20)
+		b = append(b, pubKey[:]...)
+		b = append(b, txscript.OP_CHECKSIGVERIFY)
+		b = append(b, 0x02, 0x90, 0x00)
+		b = append(b, txscript.OP_NOP) // should be OP_CHECKLOCKTIMEVERIFY
+		_, err := ValidateRefundLeafScript(hex.EncodeToString(b))
+		require.Error(t, err)
+	})
+
+	t.Run("rejects trailing bytes after a well-formed script", func(t *testing.T) {
+		pubKey := testRefundXOnlyPubKey(t)
+		valid, err := hex.DecodeString(buildRefundLeafScript(t, pubKey, 144))
+		require.NoError(t, err)
+		_, err = ValidateRefundLeafScript(hex.EncodeToString(append(valid, 0xde, 0xad)))
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
Adds fund-safety unit coverage for the BTC→ARK unilateral refund — the disaster-recovery path that lets a user reclaim BTC when Boltz goes down mid-swap. This coverage was lost when #422 migrated e2e to a cooperative live Boltz, which never exercises these failure branches. Part of #425.

## What's covered

**Refund-leaf parse** (`chainswap_validate_test.go` → `ValidateRefundLeafScript`)
Extracts the CLTV timeout + refund pubkey the whole refund depends on. 7 cases: timeout/pubkey round-trip across 2- and 3-byte pushes, plus rejection of malformed leaves (too short, wrong sig opcode, missing CLTV, trailing bytes). Synthesizes Boltz-format refund leaves with `txscript` — no live Boltz/regtest state. Mutation-verified: breaking the little-endian timeout decode makes the round-trip fail.

**Handler guards** (`chainswap_refund_test.go` → `RefundBtcToArkSwap`)
Input validation + the **CLTV gate** that refuses to broadcast a refund before its absolute timelock. A mocked `ExplorerClient` plus a synthesized regtest taproot lockup tx and Boltz response drive the handler through deserialize → output lookup → leaf parse → gate, all before any `ArkClient` call. Mutation-verified: inverting the gate comparison makes the handler treat an unreached timeout as reached and march toward a premature-refund broadcast, which the test catches.

**Post-gate broadcast** (`chainswap_refund_test.go` → `RefundBtcToArkSwap`, gate open)
The recovery payoff once the timelock opens: construct the refund tx, sign the taproot refund leaf, broadcast it, and board the reclaimed BTC via `Settle`. A fake `arksdk.ArkClient` (`NewBoardingAddress` + `Settle`) and the synthesized swap tree — whose control block is derived via the production `computeSwapTreeMerkleRoot`/`createControlBlockFromSwapTree` — drive the whole `build → sign → broadcast → confirm → settle` path with no live regtest swap. Mutation-verified: returning the settle txid instead of the broadcast txid fails the assertion.

## Finding

A sub-128 refund timeout encodes to a single byte (37-byte leaf), tripping `parseRefundHTLCScriptManually`'s hard-coded 38-byte minimum. Not reachable with real Boltz CLTV block heights (which clear 128), but pinned as a documented subtest so a parser change surfaces it.

## Scope

Covers the refund end-to-end at the unit level: parse → input/gate guards → post-gate broadcast→settle. Consensus validity of the synthesized refund tx isn't asserted (a unit test has no regtest node); the live e2e covers the cooperative path, and these tests cover the uncooperative branches it can't reach.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added refund-path coverage for BTC-to-ARK swap handling, including pre-time-lock guard checks, error propagation, and verification of broadcast transaction consensus-critical fields.
  * Added refund leaf script validation tests that round-trip timeout and pubkey parsing and assert rejection for malformed scripts (bad encoding, missing required opcodes, incorrect length/extra bytes, and invalid timeout pushes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->