### PR TITLE
feat(web): link to the delegate dashboard from the header when enabled

### DIFF
--- a/internal/interface/grpc/service.go
+++ b/internal/interface/grpc/service.go
@@ -194,7 +194,7 @@ func NewService(
 		return nil, err
 	}
 
-	feHandler := web.NewService(appSvc, feStopCh, sentryEnabled, arkServer)
+	feHandler := web.NewService(appSvc, feStopCh, sentryEnabled, arkServer, delegateSvc != nil)
 
 	mux := http.NewServeMux()
 	mux.Handle("/", feHandler)

--- a/internal/interface/web/handlers.go
+++ b/internal/interface/web/handlers.go
@@ -1092,13 +1092,13 @@ func (s *service) getHero(c *gin.Context) {
 	isSynced, err := s.svc.IsSynced()
 	if err != nil {
 		// TODO: Render error
-		partialContent := components.Hero("ERROR", false)
+		partialContent := components.Hero("ERROR", false, s.delegateEnabled)
 		partialViewHandler(partialContent, c)
 		return
 	}
 	if !isSynced {
 		// TODO: Render placeholder
-		partialContent := components.Hero("PLACEHOLDER", false)
+		partialContent := components.Hero("PLACEHOLDER", false, s.delegateEnabled)
 		partialViewHandler(partialContent, c)
 		return
 	}
@@ -1112,7 +1112,7 @@ func (s *service) getHero(c *gin.Context) {
 		log.WithError(err).Warn("failed to get spendable balance")
 	}
 
-	partialContent := components.Hero(spendableBalance, isOnline)
+	partialContent := components.Hero(spendableBalance, isOnline, s.delegateEnabled)
 	partialViewHandler(partialContent, c)
 }
 

--- a/internal/interface/web/server.go
+++ b/internal/interface/web/server.go
@@ -49,9 +49,10 @@ func (t *TemplRender) Instance(name string, data interface{}) render.Render {
 
 type service struct {
 	*gin.Engine
-	svc       *application.Service
-	stopCh    chan struct{}
-	arkServer string
+	svc             *application.Service
+	stopCh          chan struct{}
+	arkServer       string
+	delegateEnabled bool
 }
 
 func NewService(
@@ -59,6 +60,7 @@ func NewService(
 	stopCh chan struct{},
 	sentryEnabled bool,
 	arkServer string,
+	delegateEnabled bool,
 ) *service {
 	// Create a new Fiber server.
 	gin.SetMode(gin.ReleaseMode)
@@ -69,10 +71,11 @@ func NewService(
 	staticFS, _ := fs.Sub(static, "static")
 
 	svc := &service{
-		Engine:    router,
-		svc:       appSvc,
-		stopCh:    stopCh,
-		arkServer: arkServer,
+		Engine:          router,
+		svc:             appSvc,
+		stopCh:          stopCh,
+		arkServer:       arkServer,
+		delegateEnabled: delegateEnabled,
 	}
 
 	// Configure Sentry for Gin (includes built-in panic recovery)

--- a/internal/interface/web/templates/components/hero.templ
+++ b/internal/interface/web/templates/components/hero.templ
@@ -1,12 +1,17 @@
 package components
 
-templ HeroHeader() {
+templ HeroHeader(delegateEnabled bool) {
 	<div class="flex justify-between mb-10">
 	  <div class="flex gap-2 items-center">
 	    @LogoWhiteSmall()
 			@LogoNameSmall()
 		</div>
-	  <a href="/settings/general">@SettingsButton()</a>
+	  <div class="flex gap-2 items-center">
+	    if delegateEnabled {
+	      <a href="/delegate" title="Delegate">@iconButton(ServerIcon())</a>
+	    }
+	    <a href="/settings/general">@SettingsButton()</a>
+	  </div>
 	</div>
 }
 
@@ -48,9 +53,9 @@ templ Actions(online bool, currentBalance string) {
 	}
 }
 
-templ Hero(currentBalance string, online bool) {
+templ Hero(currentBalance string, online bool, delegateEnabled bool) {
   <div class="bg-orange-image rounded-b-lg md:rounded-t-lg p-3 mb-10">
-	  @HeroHeader()
+	  @HeroHeader(delegateEnabled)
 	  @HeroBalance(currentBalance)
 	  @Actions(online, currentBalance)
 	</div>

--- a/internal/interface/web/templates/components/hero_templ.go
+++ b/internal/interface/web/templates/components/hero_templ.go
@@ -8,7 +8,7 @@ package components
 import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
-func HeroHeader() templ.Component {
+func HeroHeader(delegateEnabled bool) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -41,7 +41,25 @@ func HeroHeader() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div><a href=\"/settings/general\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div><div class=\"flex gap-2 items-center\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if delegateEnabled {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<a href=\"/delegate\" title=\"Delegate\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = iconButton(ServerIcon()).Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</a> ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<a href=\"/settings/general\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -49,7 +67,7 @@ func HeroHeader() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</a></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</a></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -78,46 +96,46 @@ func HeroBalance(currentBalance string) templ.Component {
 			templ_7745c5c3_Var2 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<div class=\"mb-10\"><p class=\"text-gray-300\">Balance</p><p class=\"text-4xl font-medium my-2 cryptoAmount\" sats=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div class=\"mb-10\"><p class=\"text-gray-300\">Balance</p><p class=\"text-4xl font-medium my-2 cryptoAmount\" sats=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var3 string
 		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(currentBalance)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/components/hero.templ`, Line: 16, Col: 73}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/components/hero.templ`, Line: 21, Col: 73}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var4 string
 		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(currentBalance)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/components/hero.templ`, Line: 16, Col: 90}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/components/hero.templ`, Line: 21, Col: 90}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, " SATS</p><p class=\"text-gray-200 font-lg fiatAmount\" sats=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, " SATS</p><p class=\"text-gray-200 font-lg fiatAmount\" sats=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var5 string
 		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(currentBalance)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/components/hero.templ`, Line: 17, Col: 66}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/components/hero.templ`, Line: 22, Col: 66}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "\">&nbsp;</p></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "\">&nbsp;</p></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -147,17 +165,17 @@ func Actions(online bool, currentBalance string) templ.Component {
 		}
 		ctx = templ.ClearChildren(ctx)
 		if online {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<div class=\"grid grid-cols-3 gap-4 md:flex md:flex-row\"><button class=\"white flex items-center justify-center text-black p-2 md:px-4 md:py-3 md:w-auto\" hx-on:click=\"redirect('/send')\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<div class=\"grid grid-cols-3 gap-4 md:flex md:flex-row\"><button class=\"white flex items-center justify-center text-black p-2 md:px-4 md:py-3 md:w-auto\" hx-on:click=\"redirect('/send')\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if currentBalance == "0" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, " disabled")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, " disabled")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, ">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, ">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -165,7 +183,7 @@ func Actions(online bool, currentBalance string) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "Send</button> <button class=\"white flex items-center justify-center text-black px-2 md:px-4 md:w-auto\" hx-on:click=\"redirect('/receive')\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "Send</button> <button class=\"white flex items-center justify-center text-black px-2 md:px-4 md:w-auto\" hx-on:click=\"redirect('/receive')\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -173,7 +191,7 @@ func Actions(online bool, currentBalance string) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "Receive</button> <button class=\"white flex items-center justify-center text-black px-2 md:px-4 md:w-auto\" hx-on:click=\"redirect('/swap')\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "Receive</button> <button class=\"white flex items-center justify-center text-black px-2 md:px-4 md:w-auto\" hx-on:click=\"redirect('/swap')\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -181,12 +199,12 @@ func Actions(online bool, currentBalance string) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "Swap</button></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "Swap</button></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "<p>Server is offline</p>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<p>Server is offline</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -195,7 +213,7 @@ func Actions(online bool, currentBalance string) templ.Component {
 	})
 }
 
-func Hero(currentBalance string, online bool) templ.Component {
+func Hero(currentBalance string, online bool, delegateEnabled bool) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -216,11 +234,11 @@ func Hero(currentBalance string, online bool) templ.Component {
 			templ_7745c5c3_Var7 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<div class=\"bg-orange-image rounded-b-lg md:rounded-t-lg p-3 mb-10\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<div class=\"bg-orange-image rounded-b-lg md:rounded-t-lg p-3 mb-10\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = HeroHeader().Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = HeroHeader(delegateEnabled).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -232,7 +250,7 @@ func Hero(currentBalance string, online bool) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/interface/web/templates/components/hero_test.go
+++ b/internal/interface/web/templates/components/hero_test.go
@@ -1,0 +1,28 @@
+package components
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestHeroHeaderDelegateLink pins the delegate-dashboard link: it must appear in
+// the header only when the delegate feature is enabled. Without the feature
+// enabled the link must be absent (and historically the /delegate page was only
+// reachable by guessing the URL, which this link fixes).
+func TestHeroHeaderDelegateLink(t *testing.T) {
+	render := func(delegateEnabled bool) string {
+		var b strings.Builder
+		if err := HeroHeader(delegateEnabled).Render(context.Background(), &b); err != nil {
+			t.Fatalf("render: %v", err)
+		}
+		return b.String()
+	}
+
+	if got := render(true); !strings.Contains(got, `href="/delegate"`) {
+		t.Errorf("delegate enabled: expected a /delegate link, got:\n%s", got)
+	}
+	if got := render(false); strings.Contains(got, `href="/delegate"`) {
+		t.Errorf("delegate disabled: expected no /delegate link, got:\n%s", got)
+	}
+}


### PR DESCRIPTION
## Summary

When the delegate feature is enabled (`FULMINE_DELEGATE_ENABLED=true`), the `/delegate` dashboard had **no link anywhere in the UI** — the only way to reach it was to guess the URL and go there directly. This adds a delegate link to the main header.

## What changed

- A delegate link (`ServerIcon`) in the header, next to the settings button, rendered **only when the delegate feature is enabled**.
- The "enabled" signal is threaded from the gRPC wiring — `delegateSvc != nil`, the same check that already gates the delegate server (`internal/interface/grpc/service.go:218`) — through `web.NewService` into the `Hero` / `HeroHeader` templates (re-rendered via `/hero`, so no index/settings changes).
- No new config plumbing: `application.NewServices` returns a nil `delegateSvc` exactly when delegate is disabled, so it's a single, reliable source of truth.

## Verification

- `go build ./...` + `go vet ./internal/interface/web/... ./internal/interface/grpc/...` clean.
- Render-tested (`hero_test.go`): `HeroHeader(true)` contains `href="/delegate"`; `HeroHeader(false)` does not.

## Note on placement

I put the link in the header next to settings — the delegate dashboard is a management/monitoring view (like settings), not a wallet action. Trivial to move to an action button or a settings entry if you'd prefer a different spot.
