### PR TITLE
fix(web): remove the dead Swap button from the wallet header

### DIFF
--- a/internal/interface/web/templates/components/hero.templ
+++ b/internal/interface/web/templates/components/hero.templ
@@ -25,7 +25,7 @@ templ HeroBalance(currentBalance string) {
 
 templ Actions(online bool, currentBalance string) {
 	if online {
-	  <div class="grid grid-cols-3 gap-4 md:flex md:flex-row">
+	  <div class="grid grid-cols-2 gap-4 md:flex md:flex-row">
 	    <button
 			  class="white flex items-center justify-center text-black p-2 md:px-4 md:py-3 md:w-auto"
 				hx-on:click="redirect('/send')"
@@ -41,12 +41,6 @@ templ Actions(online bool, currentBalance string) {
 			>
 	  	  @ReceiveIcon() Receive
 	  	</button>
-			<button
-			  class="white flex items-center justify-center text-black px-2 md:px-4 md:w-auto"
-				hx-on:click="redirect('/swap')"
-			>
-				@SwapIcon() Swap
-			</button>
 	  </div>
 	} else {
 		<p>Server is offline</p>

--- a/internal/interface/web/templates/components/hero_templ.go
+++ b/internal/interface/web/templates/components/hero_templ.go
@@ -165,7 +165,7 @@ func Actions(online bool, currentBalance string) templ.Component {
 		}
 		ctx = templ.ClearChildren(ctx)
 		if online {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<div class=\"grid grid-cols-3 gap-4 md:flex md:flex-row\"><button class=\"white flex items-center justify-center text-black p-2 md:px-4 md:py-3 md:w-auto\" hx-on:click=\"redirect('/send')\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<div class=\"grid grid-cols-2 gap-4 md:flex md:flex-row\"><button class=\"white flex items-center justify-center text-black p-2 md:px-4 md:py-3 md:w-auto\" hx-on:click=\"redirect('/send')\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -191,20 +191,12 @@ func Actions(online bool, currentBalance string) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "Receive</button> <button class=\"white flex items-center justify-center text-black px-2 md:px-4 md:w-auto\" hx-on:click=\"redirect('/swap')\">")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = SwapIcon().Render(ctx, templ_7745c5c3_Buffer)
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "Swap</button></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "Receive</button></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<p>Server is offline</p>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "<p>Server is offline</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -234,7 +226,7 @@ func Hero(currentBalance string, online bool, delegateEnabled bool) templ.Compon
 			templ_7745c5c3_Var7 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<div class=\"bg-orange-image rounded-b-lg md:rounded-t-lg p-3 mb-10\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<div class=\"bg-orange-image rounded-b-lg md:rounded-t-lg p-3 mb-10\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -250,7 +242,7 @@ func Hero(currentBalance string, online bool, delegateEnabled bool) templ.Compon
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
## Summary

The Hero's **Swap** action button redirected to `/swap`, but that route was removed in #420 (which dropped the Lightning-node rebalance swap UI — its commit notes *"chain swaps are unaffected"*). Chain swaps remain an **API-only** feature (`CreateChainSwap` / `RefundChainSwap` / `ListChainSwaps`) with no UI, so the button pointed at a 404.

This removes the dead button and tightens the action grid from 3 to 2 columns (Send / Receive).

## Follow-up

Chain-swap support will be added **directly to the existing send/receive flows** (sending to a BTC address → ARK→BTC swap; receiving BTC → BTC→ARK swap) in a separate PR — better UX than a standalone swap page.

## Verification

- `go build ./internal/interface/web/...` clean.
- The existing hero render test passes (delegate-link conditional unaffected).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the action buttons in the Hero section to show a cleaner two-button layout online.
  * Removed the extra Swap button from the online actions, leaving Send and Receive.
  * Offline users still see the same “Server is offline” message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->