### PR TITLE
fix(web): add missing returns in send-preview and wallet-init handlers

### DIFF
--- a/internal/interface/web/handlers.go
+++ b/internal/interface/web/handlers.go
@@ -389,6 +389,7 @@ func (s *service) sendPreview(c *gin.Context) {
 
 		bodyContent := pages.NotePreviewContent(dest, strconv.Itoa(sats))
 		partialViewHandler(bodyContent, c)
+		return
 	}
 
 	if utils.IsBip21(dest) {

--- a/internal/interface/web/handlers.go
+++ b/internal/interface/web/handlers.go
@@ -194,6 +194,7 @@ func (s *service) initialize(c *gin.Context) {
 		log.WithError(err).Warn("failed to initialize")
 		errorContent := components.Error("Server initialization failed", "Please try again")
 		partialViewHandler(errorContent, c)
+		return
 	}
 
 	redirect("/done", c)


### PR DESCRIPTION
## Summary

Two web handlers render a response inside an `if` but don't `return`, so they fall through to code that overrides what was just rendered. Same one-line bug class, both found during self-review of #437.

### 1. Ark-note send preview (`sendPreview`)
Rendered `NotePreviewContent` for a valid Ark note but didn't `return`, falling through to the address router. A note sets no `addr`, so it then also hit the `len(addr) == 0` → "Invalid address" toast — the preview rendered **and** a spurious error toast fired.

### 2. Wallet-init error (`initialize`)
On `Setup` failure, rendered the "Server initialization failed" error but didn't `return`, falling through to `redirect("/done")`. The `HX-Redirect` header overrides the rendered body, so **a failed setup looked like a success**. Every other validation branch in the handler already returns — this was the lone omission.

## Test plan

- [x] `golangci-lint run ./internal/interface/web/...` — 0 issues (compiles + lints clean; no unreachable code)
- [x] Scanned all 13 block-indented render calls in `handlers.go` — these two were the only ones missing a `return`
- [ ] Manual: a valid Ark note preview shows no "Invalid address" toast
- [ ] Manual: a failed wallet init shows the error instead of redirecting to `/done`
