### PR TITLE
fix(core): persist VHTLC synchronously in GetSwapVHTLC

### DIFF
--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -896,14 +896,15 @@ func (s *Service) GetSwapVHTLC(
 		return "", "", nil, err
 	}
 
-	go func() {
-		if err := s.dbSvc.VHTLC().Add(context.Background(), domain.NewVhtlc(opts)); err != nil {
-			log.WithError(err).Error("failed to add vhtlc")
-			return
-		}
-
-		log.Debugf("added new vhtlc %s", vhtlcId)
-	}()
+	// Persist synchronously: the duplicate check above (VHTLC().Get) and callers
+	// like ListVHTLC read the record back immediately, so adding it in a detached
+	// goroutine raced the read — intermittently letting duplicates through and
+	// making the record briefly invisible (flaky e2e: TestVHTLC dedup and
+	// TestSettleVHTLCByDelegateRefundWithOutpoint).
+	if err := s.dbSvc.VHTLC().Add(ctx, domain.NewVhtlc(opts)); err != nil {
+		return "", "", nil, fmt.Errorf("failed to add vhtlc: %w", err)
+	}
+	log.Debugf("added new vhtlc %s", vhtlcId)
 
 	return encodedAddr, vhtlcId, vHTLCScript, nil
 }


### PR DESCRIPTION
## Summary

Fixes the root cause of a recurring flaky-e2e race. `Service.GetSwapVHTLC` ran its duplicate check (`VHTLC().Get`) **synchronously** but persisted the new VHTLC in a **detached goroutine** (`go func(){ VHTLC().Add(...) }`). Any read-after-create — a quick second `CreateVHTLC`, or an immediate `ListVHTLC` — raced the uncommitted write, so the service returned an address for a VHTLC it hadn't persisted yet.

This is a real read-after-write hazard in production code, not just a test artifact: the caller is handed an address whose VHTLC record may not exist yet.

## Fix

Persist synchronously with the request `ctx` and propagate the error (one fewer goroutine; no detached `context.Background()`):

```go
if err := s.dbSvc.VHTLC().Add(ctx, domain.NewVhtlc(opts)); err != nil {
    return "", "", nil, fmt.Errorf("failed to add vhtlc: %w", err)
}
```

The `Get` check plus the `Add`'s unique constraint now make dedup atomic, and the record is guaranteed present before `GetSwapVHTLC` returns.

## Verification

- `go build ./...` · `go vet ./internal/core/application/` — clean.
- **`TestVHTLC` 5/5** against the regtest stack — the dedup assertion that intermittently returned `nil` now passes deterministically.
- The change removes a goroutine, so the `-race` build (CI) can only be happier.

## Scope / known follow-ups (intentionally not in this PR)

- This fixes the **VHTLC-record** race — the `TestVHTLC` dedup flake and the *nil-record* failure mode of `TestSettleVHTLCByDelegateRefundWithOutpoint`.
- `TestSettleVHTLCByDelegateRefundWithOutpoint` also has a **separate, rarer sender-side flake** — `VTXO_NOT_FOUND` at the sender's second `SendOffChain` (vhtlc_test.go:895), which surfaces on stale stacks. That's the Ark SDK / arkd VTXO-propagation path, not fulmine's VHTLC, so it is **not** addressed here.
- The sibling `go func(){ Swap().Add(...) }()` patterns (service.go ~1130, ~1194) are the same latent class but are not in either flaky test's path — left for a separate change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of swap record saving by writing VHTLC data before returning success.
  * Reduced the chance of missing or delayed record persistence when requests complete successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->