### PR TITLE
fix(web): wire the dead swap/payment refund button (404)

### DIFF
--- a/internal/interface/web/handlers.go
+++ b/internal/interface/web/handlers.go
@@ -1130,6 +1130,55 @@ func (s *service) claimTx(c *gin.Context) {
 	partialViewHandler(partial, c)
 }
 
+// refundTx initiates a unilateral refund of a pending submarine swap / payment
+// from its detail page (the "Initiate Refund" button). It uses the same call the
+// startup auto-refund uses — RefundVHTLC -> RefundSwap(submarine, withoutReceiver,
+// nil outpoint) — and re-renders the detail in the "refunding" state.
+func (s *service) refundTx(c *gin.Context) {
+	if s.redirectedBecauseWalletIsLocked(c) {
+		return
+	}
+
+	txid := c.Param("txid")
+
+	swaps, err := s.svc.GetSwapHistory(c)
+	if err != nil {
+		toast := components.Toast(err.Error(), true)
+		toastHandler(toast, c)
+		return
+	}
+
+	var target *domain.Swap
+	for i := range swaps {
+		if swaps[i].Id == txid {
+			target = &swaps[i]
+			break
+		}
+	}
+	if target == nil {
+		toast := components.Toast("swap not found", true)
+		toastHandler(toast, c)
+		return
+	}
+
+	if _, err := s.svc.RefundVHTLC(c, target.Id, target.Vhtlc.Id, false, nil); err != nil {
+		toast := components.Toast(err.Error(), true)
+		toastHandler(toast, c)
+		return
+	}
+
+	if target.Type == domain.SwapPayment {
+		payment := toPayment(*target)
+		payment.Status = "refunding"
+		partialViewHandler(pages.PaymentTxRefundingContent(payment), c)
+		return
+	}
+
+	swap := toSwap(*target)
+	swap.Status = "refunding"
+	partialViewHandler(pages.SwapTxRefundingContent(swap), c)
+}
+
 func (s *service) getHero(c *gin.Context) {
 	if s.redirectedBecauseWalletIsLocked(c) {
 		return
@@ -1284,6 +1333,7 @@ func toPayment(payment domain.Swap) types.Payment {
 		Amount:         strconv.FormatUint(payment.Amount, 10),
 		Date:           prettyDay(payment.Timestamp),
 		Hour:           prettyHour(payment.Timestamp),
+		Id:             payment.Id,
 		Kind:           selectPaymentType(payment),
 		Status:         selectPaymentStatus(payment),
 		RefundLockTime: &refundLocktime,

--- a/internal/interface/web/server.go
+++ b/internal/interface/web/server.go
@@ -132,6 +132,7 @@ func NewService(
 
 	svc.POST("/helpers/bip21/validate", svc.validateBip21Api)
 	svc.POST("/helpers/claim/:txid", svc.claimTx)
+	svc.POST("/helpers/refund/:txid", svc.refundTx)
 	svc.POST("/helpers/forgot", svc.forgotApi)
 	svc.POST("/helpers/invoice/validate", svc.validateInvoiceApi)
 	svc.POST("/helpers/offer/validate", svc.validateOfferApi)


### PR DESCRIPTION
## Summary

The "Initiate Refund" button on the pending **submarine-swap** and **payment** detail pages posts to `POST /helpers/refund/:txid` — a route that was never registered (404) and had no handler. So the button has been dead: a user with a pending/expired swap or payment couldn't trigger a refund from the browser at all (only the gRPC API or the automatic startup recovery did). This is pre-existing (present on master, unrelated to the recent swap PRs).

## Fix

- **New `refundTx` web handler**: resolves the swap from history by id and calls `RefundVHTLC(swap.Id, swap.Vhtlc.Id, false /*unilateral*/, nil)` — the **same** call the startup auto-refund uses (`resumePendingSwapRefunds` → `scheduleSwapRefund` → `RefundSwap(submarine, withoutReceiver, nil outpoint)`, service.go ~2099) — then re-renders the detail in the "Refunding…" state. It dispatches payment vs submarine for the right refunding template.
- **Register** `POST /helpers/refund/:txid` next to the existing `/helpers/claim/:txid`.
- **Bug fix**: `toPayment()` never set `.Id`, so the payment refund form would have posted an empty id even once the route existed.

No template changes — the refund button + "Refunding…" states already exist in `tx.templ`; this wires the backend they pointed at.

## Verification

- `go build ./...` clean.
- The refund call is grounded in the existing auto-refund path (not a new mechanism), and mirrors the already-wired `claimTx` sibling.
- **Not exercised live**: I can't stage a genuinely pending/expired swap on demand, so the actual refund *action* is review-gated — please click it on a real expired submarine swap/payment before relying on it. The handler/route/render are mechanical.

## Follow-up (separate PR)

Chain swaps (BTC↔ARK) have **no web UI at all** — they live in a separate `ChainSwaps` repo the tx-history doesn't read, so they never appear in the dashboard and have no detail/refund page. Surfacing them is a separate, larger change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manual refund action for eligible pending swaps/payments from history.
  * Users can now trigger a refund from a transaction-specific view and see the item update to a refunding state.

* **Bug Fixes**
  * Payment records now correctly display their ID in the app, improving consistency in payment details and history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->