### PR TITLE
ci(integration): capture fulmine-user logs before the setup retry loop deletes the container

### DIFF
--- a/.github/workflows/ci.integration.yaml
+++ b/.github/workflows/ci.integration.yaml
@@ -84,6 +84,13 @@ jobs:
               sleep 2
             done
             echo "::warning::fulmine-user not initialised after attempt $attempt; recreating + retrying"
+            # Capture the container's logs before recreating it: the retry loop
+            # otherwise destroys the only record of why setup failed, so the
+            # on-failure "Stack logs" step finds "No such container: fulmine-user"
+            # and the real init error is lost.
+            echo "::group::fulmine-user logs (failed attempt $attempt)"
+            docker logs fulmine-user 2>&1 | tail -n 200 || echo "(no fulmine-user container)"
+            echo "::endgroup::"
             docker rm -f fulmine-user || true
           done
           echo "::error::fulmine-user failed to initialise after 3 attempts"


### PR DESCRIPTION
## Summary

When master went red on `462e6aa` (the #441 merge), the integration job failed at the **Start user Fulmine** setup step — `fulmine-user failed to initialise after 3 attempts`. A re-run passed, confirming a **flake** (the arkd-readiness race the step already guards against) — but the **root cause was undiagnosable**: the on-failure `Stack logs` step logged `No such container: fulmine-user`.

The reason: the setup retry loop runs `docker rm -f fulmine-user` between attempts **and after the last one**, so the container — the only place the init error lives — is gone before any log dump runs.

## Change

Dump `docker logs fulmine-user` (tail 200) on each failed attempt, **before** the container is removed:

```bash
echo "::group::fulmine-user logs (failed attempt $attempt)"
docker logs fulmine-user 2>&1 | tail -n 200 || echo "(no fulmine-user container)"
echo "::endgroup::"
docker rm -f fulmine-user || true
```

Now the next time this flakes, the workflow log shows *why* fulmine-user didn't reach `initialized:true`. The `(no fulmine-user container)` branch distinguishes "the container came up but never initialised" from "`make regtest-user-up` never created it."

## Deliberately diagnostics-only

No retry/timeout/wait changes. The actual init failure hasn't been root-caused — the evidence was being destroyed each run — so adding speculative robustness would be guessing. This PR makes the next occurrence investigable; a targeted fix can follow once there's a real failure log to read.

## Verification

- `bash -n` on the setup script block — valid.
- YAML parses cleanly (PyYAML).
- Change is confined to the **failure path** of a setup step; it doesn't touch the success path, the tests, or any product code. (It is therefore only exercised when the flake actually recurs.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic output when user startup retries fail, making it easier to understand what went wrong during initialization.
  * Added container log details for each failed attempt, including a clear message when the container is no longer available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->