### PR TITLE
chore(regtest): refresh the web wallet image on regtest-up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,9 +93,15 @@ regtest-build:
 	@docker build -t fulmine:e2e .
 
 ## regtest-up: build the image and start the arkade-regtest stack + user Fulmine
+#
+# The stack pins the web wallet at ghcr.io/arkade-os/wallet:latest, but
+# `compose up` reuses a cached image and never re-pulls it -- so a stale local
+# :latest silently masks upstream fixes (e.g. the .mjs service-worker MIME fix).
+# Refresh it before starting; a failed/offline pull is tolerated.
 regtest-up: regtest-build
 	@echo "Starting arkade-regtest stack..."
 	@git submodule update --init regtest
+	@docker pull ghcr.io/arkade-os/wallet:latest || true
 	@node regtest/regtest.mjs start --profile boltz,delegate
 	@$(MAKE) regtest-user-up
 


### PR DESCRIPTION
## Summary

`make regtest-up` pins the web wallet at `ghcr.io/arkade-os/wallet:latest`, but `docker compose up` reuses a cached image and never re-pulls it. A stale local `:latest` then silently masks upstream wallet fixes.

This bit me concretely while testing: a cached image from *before* [arkade-os/wallet#685](https://github.com/arkade-os/wallet/pull/685) served the service worker (`wallet-service-worker.mjs`) as `application/octet-stream`, so the browser refused to register it and "Create wallet" failed silently on `:3003` — even though the fix had been published upstream for over a week. Pulling the current image made create-wallet work end-to-end.

So: pull the wallet image in `regtest-up` before starting the stack, tolerating a failed/offline pull (`|| true`) so it never blocks bring-up.

## Notes

- Scoped to the wallet image (the one that caused the confusion). A broader `--pull always` for the whole stack would belong upstream in the `arkade-regtest` tool rather than here, so I kept this change fulmine-local.
- Doesn't touch CI: the integration workflow brings the stack up via `regtest.mjs` directly, not `make regtest-up`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Regtest environments now refresh the latest wallet Docker image before startup, reducing issues caused by stale cached images.
  * Improved consistency when bringing up the regtest stack after updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->