### PR TITLE
feat: amountless Lightning (LNURL) receive via lnurl-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ All settings are read from environment variables prefixed with `FULMINE_`. The m
 |----------|-------------|---------|
 | `FULMINE_BOLTZ_URL` | URL of a custom Boltz backend for swaps | Not set |
 | `FULMINE_BOLTZ_WS_URL` | URL of a custom Boltz WebSocket backend for swap events | Not set |
+| `FULMINE_LNURL_SERVER_URL` | URL of an lnurl-server for amountless Lightning receive (enables the receive page's "Lightning (any amount)" address); empty disables it | Not set |
 | `FULMINE_SWAP_TIMEOUT` | Swap timeout, in seconds | `15` |
 
 #### Advanced

--- a/cmd/fulmine/main.go
+++ b/cmd/fulmine/main.go
@@ -106,7 +106,7 @@ func main() {
 
 	appSvc, delegateSvc, err := application.NewServices(
 		buildInfo, cfg.Datadir, dbSvc, schedulerSvc,
-		cfg.EsploraURL, cfg.BoltzURL, cfg.BoltzWSURL, cfg.SwapTimeout,
+		cfg.EsploraURL, cfg.BoltzURL, cfg.BoltzWSURL, cfg.LnurlServerURL, cfg.SwapTimeout,
 		cfg.RefreshDbInterval,
 		application.DelegateConfig{
 			Enabled: cfg.DelegateEnabled,

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -14,6 +14,7 @@ Generated from `config Structure`. **Do not edit manually.**
 | `FULMINE_ESPLORA_URL` | `` | `string` | Esplora base URL (e.g., http://chopsticks:3000) |
 | `FULMINE_BOLTZ_URL` | `` | `string` | Boltz HTTP endpoint (e.g., http://boltz:9001) |
 | `FULMINE_BOLTZ_WS_URL` | `` | `string` | Boltz WebSocket endpoint (e.g., ws://boltz:9002) |
+| `FULMINE_LNURL_SERVER_URL` | `` | `string` | lnurl-server base URL for amountless Lightning receive (e.g. http://lnurl-server:3000); empty disables it |
 | `FULMINE_SCHEDULER_POLL_INTERVAL` | `600` | `int64` | Scheduler polling interval in seconds |
 | `FULMINE_PROFILING_ENABLED` | `false` | `bool` | Enable profiling endpoints |
 | `FULMINE_REFRESH_DB_INTERVAL` | `60` | `int64` | Interval in seconds to refresh the database with latest blockchain data |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -65,6 +65,7 @@ var (
 	EsploraURL            = "ESPLORA_URL"
 	BoltzURL              = "BOLTZ_URL"
 	BoltzWSURL            = "BOLTZ_WS_URL"
+	LnurlServerURL        = "LNURL_SERVER_URL"
 	DisableTelemetry      = "DISABLE_TELEMETRY"
 	NoMacaroons           = "NO_MACAROONS"
 	OtelCollectorURL      = "OTEL_COLLECTOR_URL"
@@ -158,6 +159,7 @@ func LoadConfig() (*Config, error) {
 		EsploraURL:            viper.GetString(EsploraURL),
 		BoltzURL:              viper.GetString(BoltzURL),
 		BoltzWSURL:            viper.GetString(BoltzWSURL),
+		LnurlServerURL:        viper.GetString(LnurlServerURL),
 		UnlockerType:          viper.GetString(UnlockerType),
 		UnlockerFilePath:      viper.GetString(UnlockerFilePath),
 		UnlockerPassword:      viper.GetString(UnlockerPassword),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	EsploraURL            string `mapstructure:"ESPLORA_URL" envInfo:"Esplora base URL (e.g., http://chopsticks:3000)"`
 	BoltzURL              string `mapstructure:"BOLTZ_URL" envInfo:"Boltz HTTP endpoint (e.g., http://boltz:9001)"`
 	BoltzWSURL            string `mapstructure:"BOLTZ_WS_URL" envInfo:"Boltz WebSocket endpoint (e.g., ws://boltz:9002)"`
+	LnurlServerURL        string `mapstructure:"LNURL_SERVER_URL" envInfo:"lnurl-server base URL for amountless Lightning receive (e.g. http://lnurl-server:3000); empty disables it"`
 	SchedulerPollInterval int64  `mapstructure:"SCHEDULER_POLL_INTERVAL" envDefault:"600" envInfo:"Scheduler polling interval in seconds"`
 	ProfilingEnabled      bool   `mapstructure:"PROFILING_ENABLED" envDefault:"false" envInfo:"Enable profiling endpoints"`
 	RefreshDbInterval     int64  `mapstructure:"REFRESH_DB_INTERVAL" envDefault:"60" envInfo:"Interval in seconds to refresh the database with latest blockchain data"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,20 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// LoadConfig hand-assembles Config field-by-field from viper keys: a field
+// added to the struct without a matching key constant AND assembly line stays
+// silently empty (the env-doc generator only reads struct tags, so it won't
+// catch the gap). This locks in the env->Config read for LNURL_SERVER_URL.
+func TestLoadConfigReadsLnurlServerURL(t *testing.T) {
+	t.Setenv("FULMINE_DATADIR", t.TempDir())
+	t.Setenv("FULMINE_LNURL_SERVER_URL", "http://lnurl-server:3000")
+
+	cfg, err := LoadConfig()
+	require.NoError(t, err)
+	require.Equal(t, "http://lnurl-server:3000", cfg.LnurlServerURL)
+}

--- a/internal/core/application/lnurl.go
+++ b/internal/core/application/lnurl.go
@@ -1,0 +1,47 @@
+package application
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ArkLabsHQ/fulmine/internal/lnurl"
+)
+
+// startLnurlReceiver opens a background lnurl-server session that yields a
+// stable, amountless LNURL and bridges incoming pay requests to GetInvoice.
+// Started on unlock, cancelled on lock. No-op without a configured lnurl-server
+// URL. Safe to call once per unlock.
+func (s *Service) startLnurlReceiver() {
+	if s.lnurlServerURL == "" || s.privateKey == nil {
+		return
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	s.lnurlCancel = cancel
+
+	invoiceFor := func(ctx context.Context, sats uint64) (string, error) {
+		// The swap handler is set up asynchronously on unlock; until then we
+		// can't mint invoices, so fail cleanly (the lnurl-server reports it to
+		// the payer) rather than nil-panic.
+		if s.swapHandler == nil {
+			return "", fmt.Errorf("wallet not ready")
+		}
+		resp, err := s.GetInvoice(ctx, sats)
+		if err != nil {
+			return "", err
+		}
+		return resp.Invoice, nil
+	}
+
+	c := lnurl.New(s.lnurlServerURL, s.privateKey.Serialize(), invoiceFor)
+	s.lnurlClient = c
+	go c.Run(ctx)
+}
+
+// CurrentLnurl returns the active amountless LNURL, or "" if unavailable
+// (no lnurl-server configured, wallet locked, or session not yet established).
+func (s *Service) CurrentLnurl() string {
+	if s.lnurlClient == nil {
+		return ""
+	}
+	return s.lnurlClient.Lnurl()
+}

--- a/internal/core/application/lnurl.go
+++ b/internal/core/application/lnurl.go
@@ -39,7 +39,10 @@ func (s *Service) startLnurlReceiver() {
 		}
 		resp, err := s.GetInvoice(ctx, sats)
 		if err != nil {
-			return "", err
+			// Don't relay raw Boltz/ark/network error strings to an untrusted
+			// remote payer; log the detail and return a generic message.
+			log.WithError(err).Warn("lnurl: failed to create invoice for a pay request")
+			return "", fmt.Errorf("unable to create invoice")
 		}
 		if resp == nil {
 			// GetInvoice returns (nil, nil) when Boltz rejects the amount as out

--- a/internal/core/application/lnurl.go
+++ b/internal/core/application/lnurl.go
@@ -41,6 +41,11 @@ func (s *Service) startLnurlReceiver() {
 		if err != nil {
 			return "", err
 		}
+		if resp == nil {
+			// GetInvoice returns (nil, nil) when Boltz rejects the amount as out
+			// of its swap limits; surface that rather than panicking on resp.Invoice.
+			return "", fmt.Errorf("amount is outside the supported range")
+		}
 		return resp.Invoice, nil
 	}
 

--- a/internal/core/application/lnurl.go
+++ b/internal/core/application/lnurl.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/ArkLabsHQ/fulmine/internal/lnurl"
+	log "github.com/sirupsen/logrus"
 )
 
 // startLnurlReceiver opens a background lnurl-server session that yields a
@@ -12,9 +13,20 @@ import (
 // Started on unlock, cancelled on lock. No-op without a configured lnurl-server
 // URL. Safe to call once per unlock.
 func (s *Service) startLnurlReceiver() {
-	if s.lnurlServerURL == "" || s.privateKey == nil {
+	if s.lnurlServerURL == "" {
 		return
 	}
+	if s.privateKey == nil {
+		log.Warn("lnurl: configured but wallet key unavailable; receiver not started")
+		return
+	}
+	if s.lnurlCancel != nil {
+		// Already running (called from both Setup and a later unlock); restart
+		// cleanly rather than leaking a second session.
+		s.lnurlCancel()
+		s.lnurlClient = nil
+	}
+	log.Infof("lnurl: starting receiver against %s", s.lnurlServerURL)
 	ctx, cancel := context.WithCancel(context.Background())
 	s.lnurlCancel = cancel
 

--- a/internal/core/application/lnurl.go
+++ b/internal/core/application/lnurl.go
@@ -20,6 +20,11 @@ func (s *Service) startLnurlReceiver() {
 		log.Warn("lnurl: configured but wallet key unavailable; receiver not started")
 		return
 	}
+
+	// lnurlClient/lnurlCancel are read on the web path (CurrentLnurl) and torn
+	// down by LockNode, so serialize all mutation of the pair with lnurlMu.
+	s.lnurlMu.Lock()
+	defer s.lnurlMu.Unlock()
 	if s.lnurlCancel != nil {
 		// Already running (called from both Setup and a later unlock); restart
 		// cleanly rather than leaking a second session.
@@ -60,8 +65,11 @@ func (s *Service) startLnurlReceiver() {
 // CurrentLnurl returns the active amountless LNURL, or "" if unavailable
 // (no lnurl-server configured, wallet locked, or session not yet established).
 func (s *Service) CurrentLnurl() string {
-	if s.lnurlClient == nil {
+	s.lnurlMu.Lock()
+	c := s.lnurlClient
+	s.lnurlMu.Unlock()
+	if c == nil {
 		return ""
 	}
-	return s.lnurlClient.Lnurl()
+	return c.Lnurl()
 }

--- a/internal/core/application/lnurl_race_test.go
+++ b/internal/core/application/lnurl_race_test.go
@@ -1,0 +1,50 @@
+package application
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/ArkLabsHQ/fulmine/internal/lnurl"
+)
+
+// TestCurrentLnurlConcurrentLifecycle runs the web read path (CurrentLnurl)
+// concurrently with writers that swap lnurlClient the way startLnurlReceiver and
+// LockNode do. Before lnurlMu guarded the pair, CurrentLnurl's check-then-use
+// (read the pointer, then re-read it to call .Lnurl()) could dereference a
+// freshly nil'd client and panic, and the unsynchronized access tripped the race
+// detector. This guards that fix and must stay clean under `go test -race`.
+func TestCurrentLnurlConcurrentLifecycle(t *testing.T) {
+	s := &Service{}
+	client := lnurl.New("https://example.com", []byte{1, 2, 3}, func(context.Context, uint64) (string, error) {
+		return "", nil
+	})
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() { // the web handler read path
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = s.CurrentLnurl()
+			}
+		}
+	}()
+
+	for i := 0; i < 5000; i++ { // unlock sets a client, lock tears it down
+		s.lnurlMu.Lock()
+		s.lnurlClient = client
+		s.lnurlMu.Unlock()
+		s.lnurlMu.Lock()
+		s.lnurlClient = nil
+		s.lnurlMu.Unlock()
+	}
+
+	close(stop)
+	wg.Wait()
+}

--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -570,6 +570,10 @@ func (s *Service) UnlockNode(ctx context.Context, password string) error {
 
 		go s.recoverChainSwaps(context.Background(), arkConfig)
 
+		// Start here, inside the post-sync goroutine: privateKey (above) and
+		// swapHandler (used by the invoice callback) are only set here.
+		s.startLnurlReceiver()
+
 		s.sanitize(context.Background())
 	}()
 
@@ -582,8 +586,6 @@ func (s *Service) UnlockNode(ctx context.Context, password string) error {
 		wsUrl = boltzURLByNetwork[arkConfig.Network.Name]
 	}
 	s.boltzSvc = &boltz.Api{URL: url, WSURL: wsUrl}
-
-	s.startLnurlReceiver()
 
 	go func() {
 		s.walletUpdates <- WalletUpdate{Type: WalletUnlock, Password: password}

--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -103,6 +103,7 @@ type Service struct {
 	boltzWSUrl string
 
 	lnurlServerURL string
+	lnurlMu        sync.Mutex // guards lnurlClient/lnurlCancel: read on the web path, written on lock/unlock
 	lnurlClient    *lnurl.Client
 	lnurlCancel    context.CancelFunc
 
@@ -440,11 +441,13 @@ func (s *Service) LockNode(ctx context.Context) error {
 		s.onLock()
 	}
 
+	s.lnurlMu.Lock()
 	if s.lnurlCancel != nil {
 		s.lnurlCancel()
 		s.lnurlCancel = nil
 		s.lnurlClient = nil
 	}
+	s.lnurlMu.Unlock()
 
 	if s.schedulerSvc != nil {
 		s.schedulerSvc.Stop()

--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/ArkLabsHQ/fulmine/internal/core/domain"
 	"github.com/ArkLabsHQ/fulmine/internal/core/ports"
+	"github.com/ArkLabsHQ/fulmine/internal/lnurl"
 	"github.com/ArkLabsHQ/fulmine/pkg/boltz"
 	"github.com/ArkLabsHQ/fulmine/pkg/swap"
 	"github.com/ArkLabsHQ/fulmine/pkg/vhtlc"
@@ -101,6 +102,10 @@ type Service struct {
 	boltzUrl   string
 	boltzWSUrl string
 
+	lnurlServerURL string
+	lnurlClient    *lnurl.Client
+	lnurlCancel    context.CancelFunc
+
 	swapTimeout uint32
 
 	isInitialized bool
@@ -150,13 +155,13 @@ func NewServices(
 	datadir string,
 	dbSvc ports.RepoManager,
 	schedulerSvc ports.SchedulerService,
-	esploraUrl, boltzUrl, boltzWSUrl string, swapTimeout uint32,
+	esploraUrl, boltzUrl, boltzWSUrl, lnurlServerURL string, swapTimeout uint32,
 	refreshDbInterval int64,
 	delegateConfig DelegateConfig,
 ) (*Service, *DelegateService, error) {
 	svc, err := newService(
 		buildInfo, datadir, dbSvc, schedulerSvc, refreshDbInterval,
-		esploraUrl, boltzUrl, boltzWSUrl, swapTimeout,
+		esploraUrl, boltzUrl, boltzWSUrl, lnurlServerURL, swapTimeout,
 	)
 	if err != nil {
 		return nil, nil, err
@@ -182,7 +187,7 @@ func newService(
 	dbSvc ports.RepoManager,
 	schedulerSvc ports.SchedulerService,
 	refreshDbInterval int64,
-	esploraUrl, boltzUrl, boltzWSUrl string, swapTimeout uint32,
+	esploraUrl, boltzUrl, boltzWSUrl, lnurlServerURL string, swapTimeout uint32,
 ) (*Service, error) {
 	walletStore, err := filestore.NewWalletStore(datadir)
 	if err != nil {
@@ -218,6 +223,7 @@ func newService(
 			esploraUrl:            data.ExplorerURL,
 			boltzUrl:              boltzUrl,
 			boltzWSUrl:            boltzWSUrl,
+			lnurlServerURL:        lnurlServerURL,
 			swapTimeout:           swapTimeout,
 			walletUpdates:         make(chan WalletUpdate),
 			syncLock:              &sync.RWMutex{},
@@ -422,6 +428,12 @@ func (s *Service) LockNode(ctx context.Context) error {
 		s.onLock()
 	}
 
+	if s.lnurlCancel != nil {
+		s.lnurlCancel()
+		s.lnurlCancel = nil
+		s.lnurlClient = nil
+	}
+
 	if s.schedulerSvc != nil {
 		s.schedulerSvc.Stop()
 		log.Info("scheduler stopped")
@@ -570,6 +582,8 @@ func (s *Service) UnlockNode(ctx context.Context, password string) error {
 		wsUrl = boltzURLByNetwork[arkConfig.Network.Name]
 	}
 	s.boltzSvc = &boltz.Api{URL: url, WSURL: wsUrl}
+
+	s.startLnurlReceiver()
 
 	go func() {
 		s.walletUpdates <- WalletUpdate{Type: WalletUnlock, Password: password}

--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -404,9 +404,14 @@ func (s *Service) Setup(ctx context.Context, serverUrl, password, privateKey str
 	s.isInitialized = true
 
 	// Setup brings the wallet online without going through UnlockNode (which
-	// early-returns here because the ArkClient is already unlocked), so start
-	// the amountless LNURL receiver here. It only needs the key + server URL,
-	// both set above.
+	// early-returns here because the ArkClient is already unlocked). Build the
+	// swap handler now so the LNURL receiver started just below can actually
+	// mint invoices on a fresh setup -- otherwise pay requests fail with
+	// "wallet not ready" until the user locks and unlocks again.
+	// nolint
+	s.swapHandler, _ = swap.NewSwapHandler(
+		s.ArkClient, s.boltzSvc, s.esploraUrl, s.privateKey, s.swapTimeout,
+	)
 	s.startLnurlReceiver()
 
 	// Revitilise all Swaps If Present

--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -263,6 +263,7 @@ func newService(
 		esploraUrl:            esploraUrl,
 		boltzUrl:              boltzUrl,
 		boltzWSUrl:            boltzWSUrl,
+		lnurlServerURL:        lnurlServerURL,
 		swapTimeout:           swapTimeout,
 		walletUpdates:         make(chan WalletUpdate),
 		syncLock:              &sync.RWMutex{},
@@ -401,6 +402,12 @@ func (s *Service) Setup(ctx context.Context, serverUrl, password, privateKey str
 	s.publicKey = prvKey.PubKey()
 	s.privateKey = prvKey
 	s.isInitialized = true
+
+	// Setup brings the wallet online without going through UnlockNode (which
+	// early-returns here because the ArkClient is already unlocked), so start
+	// the amountless LNURL receiver here. It only needs the key + server URL,
+	// both set above.
+	s.startLnurlReceiver()
 
 	// Revitilise all Swaps If Present
 	if err := s.restoreSwapHistory(ctx); err != nil {

--- a/internal/interface/web/handlers.go
+++ b/internal/interface/web/handlers.go
@@ -314,33 +314,6 @@ func (s *service) receiveQrCode(c *gin.Context) {
 	s.pageViewHandler(bodyContent, c)
 }
 
-func (s *service) receiveLightning(c *gin.Context) {
-	if s.redirectedBecauseWalletIsLocked(c) {
-		return
-	}
-	sats, err := strconv.ParseUint(c.PostForm("sats"), 10, 0)
-	if err != nil || sats == 0 {
-		toast := components.Toast("enter an amount", true)
-		toastHandler(toast, c)
-		return
-	}
-	resp, err := s.svc.GetInvoice(c, sats)
-	if err != nil {
-		toast := components.Toast(err.Error(), true)
-		toastHandler(toast, c)
-		return
-	}
-	png, err := qrcode.Encode(resp.Invoice, qrcode.Medium, 256)
-	if err != nil {
-		// nolint:all
-		c.AbortWithError(http.StatusInternalServerError, err)
-		return
-	}
-	encoded := base64.StdEncoding.EncodeToString(png)
-	bodyContent := pages.ReceiveInvoiceContent(resp.Invoice, fmt.Sprintf("%d", sats), encoded)
-	s.pageViewHandler(bodyContent, c)
-}
-
 func (s *service) receiveSwap(c *gin.Context) {
 	if s.redirectedBecauseWalletIsLocked(c) {
 		return

--- a/internal/interface/web/handlers.go
+++ b/internal/interface/web/handlers.go
@@ -310,7 +310,34 @@ func (s *service) receiveQrCode(c *gin.Context) {
 	}
 	encoded := base64.StdEncoding.EncodeToString(png)
 
-	bodyContent := pages.ReceiveQrCodeContent(bip21, offchainAddr, boardingAddr, invoice, encoded, fmt.Sprintf("%d", sats))
+	bodyContent := pages.ReceiveQrCodeContent(bip21, offchainAddr, boardingAddr, invoice, encoded, fmt.Sprintf("%d", sats), s.svc.CurrentLnurl())
+	s.pageViewHandler(bodyContent, c)
+}
+
+func (s *service) receiveLightning(c *gin.Context) {
+	if s.redirectedBecauseWalletIsLocked(c) {
+		return
+	}
+	sats, err := strconv.ParseUint(c.PostForm("sats"), 10, 0)
+	if err != nil || sats == 0 {
+		toast := components.Toast("enter an amount", true)
+		toastHandler(toast, c)
+		return
+	}
+	resp, err := s.svc.GetInvoice(c, sats)
+	if err != nil {
+		toast := components.Toast(err.Error(), true)
+		toastHandler(toast, c)
+		return
+	}
+	png, err := qrcode.Encode(resp.Invoice, qrcode.Medium, 256)
+	if err != nil {
+		// nolint:all
+		c.AbortWithError(http.StatusInternalServerError, err)
+		return
+	}
+	encoded := base64.StdEncoding.EncodeToString(png)
+	bodyContent := pages.ReceiveInvoiceContent(resp.Invoice, fmt.Sprintf("%d", sats), encoded)
 	s.pageViewHandler(bodyContent, c)
 }
 

--- a/internal/interface/web/server.go
+++ b/internal/interface/web/server.go
@@ -128,7 +128,6 @@ func NewService(
 	svc.POST("/receive/preview", svc.receiveQrCode)
 	svc.POST("/receive/success", svc.receiveSuccess)
 	svc.POST("/receive/swap", svc.receiveSwap)
-	svc.POST("/receive/lightning", svc.receiveLightning)
 	svc.POST("/send/preview", svc.sendPreview)
 	svc.POST("/send/confirm", svc.sendConfirm)
 

--- a/internal/interface/web/server.go
+++ b/internal/interface/web/server.go
@@ -128,6 +128,7 @@ func NewService(
 	svc.POST("/receive/preview", svc.receiveQrCode)
 	svc.POST("/receive/success", svc.receiveSuccess)
 	svc.POST("/receive/swap", svc.receiveSwap)
+	svc.POST("/receive/lightning", svc.receiveLightning)
 	svc.POST("/send/preview", svc.sendPreview)
 	svc.POST("/send/confirm", svc.sendConfirm)
 

--- a/internal/interface/web/templates/pages/receive.templ
+++ b/internal/interface/web/templates/pages/receive.templ
@@ -36,7 +36,7 @@ templ ReceiveEditContent() {
 	</script>
 }
 
-templ ReceiveQrCodeContent(bip21, offchainAddr, boardingAddr, invoice, encoded, sats string) {
+templ ReceiveQrCodeContent(bip21, offchainAddr, boardingAddr, invoice, encoded, sats, lnurl string) {
 	<form id="success" hx-post="/receive/success" hx-ext="sse" sse-connect="/events" hx-trigger="sse:TXS_ADDED">
 	  @components.DesktopHeader()
 	  <input class="hidden" id="submitButton" type="submit"/>
@@ -61,6 +61,9 @@ templ ReceiveQrCodeContent(bip21, offchainAddr, boardingAddr, invoice, encoded, 
 					if len(invoice) > 0 {
 						@addressLine("Lightning invoice", invoice)
 					}
+					if len(lnurl) > 0 {
+						@addressLine("Lightning (any amount)", lnurl)
+					}
 				</div>
 	  	</div>
       <div class="flex flex-col md:flex-row justify-start gap-4 mt-10 mb-2">
@@ -71,6 +74,9 @@ templ ReceiveQrCodeContent(bip21, offchainAddr, boardingAddr, invoice, encoded, 
 			if sats != "0" {
 				<button type="button" class="button md:w-auto" hx-post="/receive/swap" hx-include="[name='sats']" hx-target="#success" hx-swap="outerHTML">
 					<span class="ml-2">Receive via BTC</span>
+				</button>
+				<button type="button" class="button md:w-auto" hx-post="/receive/lightning" hx-include="[name='sats']" hx-target="#success" hx-swap="outerHTML">
+					<span class="ml-2">Receive via Lightning</span>
 				</button>
 			}
 	    </div>
@@ -94,6 +100,29 @@ templ ReceiveSuccessContent(offchainAddr, sats string) {
 		</div>
 	</div>
 }
+templ ReceiveInvoiceContent(invoice, amount, encoded string) {
+	@components.DesktopHeader()
+	<div id="receiveBody">
+	  <div class="p-3 flex flex-col justify-between rounded-lg h-screen md:h-auto md:bg-desktopbg">
+	    @components.Header("Receive via Lightning")
+	    <div class="flex flex-col justify-center items-center gap-2">
+	      <p class="mt-2 text-center text-white/50 w-11/12 max-w-[600px]">Pay this Lightning invoice for <span class="cryptoAmount" sats={amount}>{amount} SATS</span>. Your Ark balance updates once it settles.</p>
+	      <div class="h-64 my-6">
+	        <img src={"data:image/png;base64," + encoded} alt="qrcode for lightning invoice" title={invoice}>
+	      </div>
+	      <div class="flex flex-col gap-2 w-11/12 max-w-[600px]">
+	        @addressLine("Lightning invoice", invoice)
+	      </div>
+	    </div>
+	    <div class="flex flex-col md:flex-row justify-start gap-4 mt-10 mb-2">
+	      <a class="button md:w-auto" onclick="redirect('/receive')">
+	        <span class="ml-2">Done</span>
+	      </a>
+	    </div>
+	  </div>
+	</div>
+}
+
 templ ReceiveSwapContent(lockupAddr, amount, encoded string) {
 	@components.DesktopHeader()
 	<div id="receiveBody">

--- a/internal/interface/web/templates/pages/receive.templ
+++ b/internal/interface/web/templates/pages/receive.templ
@@ -75,9 +75,6 @@ templ ReceiveQrCodeContent(bip21, offchainAddr, boardingAddr, invoice, encoded, 
 				<button type="button" class="button md:w-auto" hx-post="/receive/swap" hx-include="[name='sats']" hx-target="#success" hx-swap="outerHTML">
 					<span class="ml-2">Receive via BTC</span>
 				</button>
-				<button type="button" class="button md:w-auto" hx-post="/receive/lightning" hx-include="[name='sats']" hx-target="#success" hx-swap="outerHTML">
-					<span class="ml-2">Receive via Lightning</span>
-				</button>
 			}
 	    </div>
 	  </div>
@@ -100,29 +97,6 @@ templ ReceiveSuccessContent(offchainAddr, sats string) {
 		</div>
 	</div>
 }
-templ ReceiveInvoiceContent(invoice, amount, encoded string) {
-	@components.DesktopHeader()
-	<div id="receiveBody">
-	  <div class="p-3 flex flex-col justify-between rounded-lg h-screen md:h-auto md:bg-desktopbg">
-	    @components.Header("Receive via Lightning")
-	    <div class="flex flex-col justify-center items-center gap-2">
-	      <p class="mt-2 text-center text-white/50 w-11/12 max-w-[600px]">Pay this Lightning invoice for <span class="cryptoAmount" sats={amount}>{amount} SATS</span>. Your Ark balance updates once it settles.</p>
-	      <div class="h-64 my-6">
-	        <img src={"data:image/png;base64," + encoded} alt="qrcode for lightning invoice" title={invoice}>
-	      </div>
-	      <div class="flex flex-col gap-2 w-11/12 max-w-[600px]">
-	        @addressLine("Lightning invoice", invoice)
-	      </div>
-	    </div>
-	    <div class="flex flex-col md:flex-row justify-start gap-4 mt-10 mb-2">
-	      <a class="button md:w-auto" onclick="redirect('/receive')">
-	        <span class="ml-2">Done</span>
-	      </a>
-	    </div>
-	  </div>
-	</div>
-}
-
 templ ReceiveSwapContent(lockupAddr, amount, encoded string) {
 	@components.DesktopHeader()
 	<div id="receiveBody">

--- a/internal/interface/web/templates/pages/receive_templ.go
+++ b/internal/interface/web/templates/pages/receive_templ.go
@@ -132,7 +132,7 @@ func ReceiveEditContent() templ.Component {
 	})
 }
 
-func ReceiveQrCodeContent(bip21, offchainAddr, boardingAddr, invoice, encoded, sats string) templ.Component {
+func ReceiveQrCodeContent(bip21, offchainAddr, boardingAddr, invoice, encoded, sats, lnurl string) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -249,6 +249,12 @@ func ReceiveQrCodeContent(bip21, offchainAddr, boardingAddr, invoice, encoded, s
 				return templ_7745c5c3_Err
 			}
 		}
+		if len(lnurl) > 0 {
+			templ_7745c5c3_Err = addressLine("Lightning (any amount)", lnurl).Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
 		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</div></div><div class=\"flex flex-col md:flex-row justify-start gap-4 mt-10 mb-2\"><a class=\"button md:w-auto\" onclick=\"redirect('/receive/edit')\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
@@ -262,7 +268,7 @@ func ReceiveQrCodeContent(bip21, offchainAddr, boardingAddr, invoice, encoded, s
 			return templ_7745c5c3_Err
 		}
 		if sats != "0" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<button type=\"button\" class=\"button md:w-auto\" hx-post=\"/receive/swap\" hx-include=\"[name='sats']\" hx-target=\"#success\" hx-swap=\"outerHTML\"><span class=\"ml-2\">Receive via BTC</span></button>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<button type=\"button\" class=\"button md:w-auto\" hx-post=\"/receive/swap\" hx-include=\"[name='sats']\" hx-target=\"#success\" hx-swap=\"outerHTML\"><span class=\"ml-2\">Receive via BTC</span></button> <button type=\"button\" class=\"button md:w-auto\" hx-post=\"/receive/lightning\" hx-include=\"[name='sats']\" hx-target=\"#success\" hx-swap=\"outerHTML\"><span class=\"ml-2\">Receive via Lightning</span></button>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -319,7 +325,7 @@ func ReceiveSuccessContent(offchainAddr, sats string) templ.Component {
 		var templ_7745c5c3_Var11 string
 		templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(sats)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 88, Col: 51}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 94, Col: 51}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 		if templ_7745c5c3_Err != nil {
@@ -332,7 +338,7 @@ func ReceiveSuccessContent(offchainAddr, sats string) templ.Component {
 		var templ_7745c5c3_Var12 string
 		templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(sats)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 88, Col: 58}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 94, Col: 58}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 		if templ_7745c5c3_Err != nil {
@@ -345,7 +351,7 @@ func ReceiveSuccessContent(offchainAddr, sats string) templ.Component {
 		var templ_7745c5c3_Var13 string
 		templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(offchainAddr)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 91, Col: 93}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 97, Col: 93}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 		if templ_7745c5c3_Err != nil {
@@ -367,7 +373,7 @@ func ReceiveSuccessContent(offchainAddr, sats string) templ.Component {
 	})
 }
 
-func ReceiveSwapContent(lockupAddr, amount, encoded string) templ.Component {
+func ReceiveInvoiceContent(invoice, amount, encoded string) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -396,18 +402,18 @@ func ReceiveSwapContent(lockupAddr, amount, encoded string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = components.Header("Receive via BTC").Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = components.Header("Receive via Lightning").Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<div class=\"flex flex-col justify-center items-center gap-2\"><p class=\"mt-2 text-center text-white/50 w-11/12 max-w-[600px]\">Send <span class=\"cryptoAmount\" sats=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<div class=\"flex flex-col justify-center items-center gap-2\"><p class=\"mt-2 text-center text-white/50 w-11/12 max-w-[600px]\">Pay this Lightning invoice for <span class=\"cryptoAmount\" sats=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var15 string
 		templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(amount)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 103, Col: 115}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 109, Col: 141}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 		if templ_7745c5c3_Err != nil {
@@ -420,33 +426,33 @@ func ReceiveSwapContent(lockupAddr, amount, encoded string) templ.Component {
 		var templ_7745c5c3_Var16 string
 		templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(amount)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 103, Col: 124}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 109, Col: 150}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, " SATS</span> of on-chain BTC to the address below. Your Ark balance updates once the swap confirms.</p><div class=\"h-64 my-6\"><img src=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, " SATS</span>. Your Ark balance updates once it settles.</p><div class=\"h-64 my-6\"><img src=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var17 string
 		templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs("data:image/png;base64," + encoded)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 105, Col: 53}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 111, Col: 53}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "\" alt=\"qrcode for BTC lockup address\" title=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "\" alt=\"qrcode for lightning invoice\" title=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var18 string
-		templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(lockupAddr)
+		templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(invoice)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 105, Col: 108}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 111, Col: 104}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 		if templ_7745c5c3_Err != nil {
@@ -456,11 +462,112 @@ func ReceiveSwapContent(lockupAddr, amount, encoded string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = addressLine("BTC lockup address", lockupAddr).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = addressLine("Lightning invoice", invoice).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "</div></div><div class=\"flex flex-col md:flex-row justify-start gap-4 mt-10 mb-2\"><a class=\"button md:w-auto\" onclick=\"redirect('/receive')\"><span class=\"ml-2\">Done</span></a></div></div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+func ReceiveSwapContent(lockupAddr, amount, encoded string) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var19 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var19 == nil {
+			templ_7745c5c3_Var19 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = components.DesktopHeader().Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "<div id=\"receiveBody\"><div class=\"p-3 flex flex-col justify-between rounded-lg h-screen md:h-auto md:bg-desktopbg\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = components.Header("Receive via BTC").Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "<div class=\"flex flex-col justify-center items-center gap-2\"><p class=\"mt-2 text-center text-white/50 w-11/12 max-w-[600px]\">Send <span class=\"cryptoAmount\" sats=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var20 string
+		templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(amount)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 132, Col: 115}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var21 string
+		templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(amount)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 132, Col: 124}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, " SATS</span> of on-chain BTC to the address below. Your Ark balance updates once the swap confirms.</p><div class=\"h-64 my-6\"><img src=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var22 string
+		templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs("data:image/png;base64," + encoded)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 134, Col: 53}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "\" alt=\"qrcode for BTC lockup address\" title=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var23 string
+		templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(lockupAddr)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 134, Col: 108}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "\"></div><div class=\"flex flex-col gap-2 w-11/12 max-w-[600px]\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = addressLine("BTC lockup address", lockupAddr).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "</div></div><div class=\"flex flex-col md:flex-row justify-start gap-4 mt-10 mb-2\"><a class=\"button md:w-auto\" onclick=\"redirect('/receive')\"><span class=\"ml-2\">Done</span></a></div></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/interface/web/templates/pages/receive_templ.go
+++ b/internal/interface/web/templates/pages/receive_templ.go
@@ -268,7 +268,7 @@ func ReceiveQrCodeContent(bip21, offchainAddr, boardingAddr, invoice, encoded, s
 			return templ_7745c5c3_Err
 		}
 		if sats != "0" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<button type=\"button\" class=\"button md:w-auto\" hx-post=\"/receive/swap\" hx-include=\"[name='sats']\" hx-target=\"#success\" hx-swap=\"outerHTML\"><span class=\"ml-2\">Receive via BTC</span></button> <button type=\"button\" class=\"button md:w-auto\" hx-post=\"/receive/lightning\" hx-include=\"[name='sats']\" hx-target=\"#success\" hx-swap=\"outerHTML\"><span class=\"ml-2\">Receive via Lightning</span></button>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<button type=\"button\" class=\"button md:w-auto\" hx-post=\"/receive/swap\" hx-include=\"[name='sats']\" hx-target=\"#success\" hx-swap=\"outerHTML\"><span class=\"ml-2\">Receive via BTC</span></button>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -325,7 +325,7 @@ func ReceiveSuccessContent(offchainAddr, sats string) templ.Component {
 		var templ_7745c5c3_Var11 string
 		templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(sats)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 94, Col: 51}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 91, Col: 51}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 		if templ_7745c5c3_Err != nil {
@@ -338,7 +338,7 @@ func ReceiveSuccessContent(offchainAddr, sats string) templ.Component {
 		var templ_7745c5c3_Var12 string
 		templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(sats)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 94, Col: 58}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 91, Col: 58}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 		if templ_7745c5c3_Err != nil {
@@ -351,7 +351,7 @@ func ReceiveSuccessContent(offchainAddr, sats string) templ.Component {
 		var templ_7745c5c3_Var13 string
 		templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(offchainAddr)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 97, Col: 93}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 94, Col: 93}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 		if templ_7745c5c3_Err != nil {
@@ -373,7 +373,7 @@ func ReceiveSuccessContent(offchainAddr, sats string) templ.Component {
 	})
 }
 
-func ReceiveInvoiceContent(invoice, amount, encoded string) templ.Component {
+func ReceiveSwapContent(lockupAddr, amount, encoded string) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -402,18 +402,18 @@ func ReceiveInvoiceContent(invoice, amount, encoded string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = components.Header("Receive via Lightning").Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = components.Header("Receive via BTC").Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<div class=\"flex flex-col justify-center items-center gap-2\"><p class=\"mt-2 text-center text-white/50 w-11/12 max-w-[600px]\">Pay this Lightning invoice for <span class=\"cryptoAmount\" sats=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<div class=\"flex flex-col justify-center items-center gap-2\"><p class=\"mt-2 text-center text-white/50 w-11/12 max-w-[600px]\">Send <span class=\"cryptoAmount\" sats=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var15 string
 		templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(amount)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 109, Col: 141}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 106, Col: 115}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 		if templ_7745c5c3_Err != nil {
@@ -426,33 +426,33 @@ func ReceiveInvoiceContent(invoice, amount, encoded string) templ.Component {
 		var templ_7745c5c3_Var16 string
 		templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(amount)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 109, Col: 150}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 106, Col: 124}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, " SATS</span>. Your Ark balance updates once it settles.</p><div class=\"h-64 my-6\"><img src=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, " SATS</span> of on-chain BTC to the address below. Your Ark balance updates once the swap confirms.</p><div class=\"h-64 my-6\"><img src=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var17 string
 		templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs("data:image/png;base64," + encoded)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 111, Col: 53}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 108, Col: 53}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "\" alt=\"qrcode for lightning invoice\" title=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "\" alt=\"qrcode for BTC lockup address\" title=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var18 string
-		templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(invoice)
+		templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(lockupAddr)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 111, Col: 104}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 108, Col: 108}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 		if templ_7745c5c3_Err != nil {
@@ -462,112 +462,11 @@ func ReceiveInvoiceContent(invoice, amount, encoded string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = addressLine("Lightning invoice", invoice).Render(ctx, templ_7745c5c3_Buffer)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "</div></div><div class=\"flex flex-col md:flex-row justify-start gap-4 mt-10 mb-2\"><a class=\"button md:w-auto\" onclick=\"redirect('/receive')\"><span class=\"ml-2\">Done</span></a></div></div></div>")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		return nil
-	})
-}
-
-func ReceiveSwapContent(lockupAddr, amount, encoded string) templ.Component {
-	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
-		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
-		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
-			return templ_7745c5c3_CtxErr
-		}
-		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
-		if !templ_7745c5c3_IsBuffer {
-			defer func() {
-				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
-				if templ_7745c5c3_Err == nil {
-					templ_7745c5c3_Err = templ_7745c5c3_BufErr
-				}
-			}()
-		}
-		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var19 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var19 == nil {
-			templ_7745c5c3_Var19 = templ.NopComponent
-		}
-		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = components.DesktopHeader().Render(ctx, templ_7745c5c3_Buffer)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "<div id=\"receiveBody\"><div class=\"p-3 flex flex-col justify-between rounded-lg h-screen md:h-auto md:bg-desktopbg\">")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = components.Header("Receive via BTC").Render(ctx, templ_7745c5c3_Buffer)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "<div class=\"flex flex-col justify-center items-center gap-2\"><p class=\"mt-2 text-center text-white/50 w-11/12 max-w-[600px]\">Send <span class=\"cryptoAmount\" sats=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var20 string
-		templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(amount)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 132, Col: 115}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "\">")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var21 string
-		templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(amount)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 132, Col: 124}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, " SATS</span> of on-chain BTC to the address below. Your Ark balance updates once the swap confirms.</p><div class=\"h-64 my-6\"><img src=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var22 string
-		templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs("data:image/png;base64," + encoded)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 134, Col: 53}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "\" alt=\"qrcode for BTC lockup address\" title=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var23 string
-		templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(lockupAddr)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 134, Col: 108}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "\"></div><div class=\"flex flex-col gap-2 w-11/12 max-w-[600px]\">")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
 		templ_7745c5c3_Err = addressLine("BTC lockup address", lockupAddr).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "</div></div><div class=\"flex flex-col md:flex-row justify-start gap-4 mt-10 mb-2\"><a class=\"button md:w-auto\" onclick=\"redirect('/receive')\"><span class=\"ml-2\">Done</span></a></div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "</div></div><div class=\"flex flex-col md:flex-row justify-start gap-4 mt-10 mb-2\"><a class=\"button md:w-auto\" onclick=\"redirect('/receive')\"><span class=\"ml-2\">Done</span></a></div></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/lnurl/client.go
+++ b/internal/lnurl/client.go
@@ -142,6 +142,14 @@ func (c *Client) connect(ctx context.Context) error {
 }
 
 func (c *Client) handleInvoiceRequest(ctx context.Context, sessionID, token string, amountMsat int64) {
+	// This processes untrusted remote input; contain any panic to this request
+	// rather than letting it unwind through the session goroutine and crash the
+	// daemon.
+	defer func() {
+		if r := recover(); r != nil {
+			log.Errorf("lnurl: recovered from panic handling an invoice request: %v", r)
+		}
+	}()
 	post := func(payload string) {
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost,
 			fmt.Sprintf("%s/lnurl/session/%s/invoice", c.baseURL, sessionID),

--- a/internal/lnurl/client.go
+++ b/internal/lnurl/client.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 )
 
 // InvoiceFunc generates a BOLT11 invoice to receive `sats` (fulmine's GetInvoice).
@@ -70,6 +72,7 @@ func (c *Client) Run(ctx context.Context) {
 			return
 		}
 		if err != nil {
+			log.WithError(err).Warn("lnurl: session error, retrying")
 			time.Sleep(backoff)
 			if backoff < 30*time.Second {
 				backoff *= 2
@@ -117,6 +120,9 @@ func (c *Client) connect(ctx context.Context) error {
 				if err := json.Unmarshal([]byte(data), &d); err == nil {
 					sessionID, authToken = d.SessionId, d.Token
 					c.setLnurl(d.Lnurl)
+					log.Infof("lnurl: session established, lnurl=%s", d.Lnurl)
+				} else {
+					log.WithError(err).Warnf("lnurl: bad session_created data: %s", data)
 				}
 			case "invoice_request":
 				var d struct {

--- a/internal/lnurl/client.go
+++ b/internal/lnurl/client.go
@@ -128,7 +128,9 @@ func (c *Client) connect(ctx context.Context) error {
 				var d struct {
 					AmountMsat int64 `json:"amountMsat"`
 				}
-				if err := json.Unmarshal([]byte(data), &d); err == nil {
+				if err := json.Unmarshal([]byte(data), &d); err != nil {
+					log.WithError(err).Warnf("lnurl: bad invoice_request data: %s", data)
+				} else {
 					c.handleInvoiceRequest(ctx, sessionID, authToken, d.AmountMsat)
 				}
 			}
@@ -151,12 +153,24 @@ func (c *Client) handleInvoiceRequest(ctx context.Context, sessionID, token stri
 		if token != "" {
 			req.Header.Set("Authorization", "Bearer "+token)
 		}
-		if resp, err := http.DefaultClient.Do(req); err == nil {
-			resp.Body.Close()
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			log.WithError(err).Warn("lnurl: failed to post invoice result")
+			return
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode/100 != 2 {
+			log.Warnf("lnurl: invoice-result POST returned HTTP %d", resp.StatusCode)
 		}
 	}
 	if amountMsat <= 0 {
 		post(`{"error":"invalid amount"}`)
+		return
+	}
+	if amountMsat%1000 != 0 {
+		// We mint whole-sat invoices; flooring a sub-sat request would make the
+		// invoice amount disagree with what the sender approved, so reject it.
+		post(`{"error":"sub-satoshi amounts are not supported"}`)
 		return
 	}
 	pr, err := c.invoiceFor(ctx, uint64(amountMsat)/1000)

--- a/internal/lnurl/client.go
+++ b/internal/lnurl/client.go
@@ -1,0 +1,166 @@
+package lnurl
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// InvoiceFunc generates a BOLT11 invoice to receive `sats` (fulmine's GetInvoice).
+type InvoiceFunc func(ctx context.Context, sats uint64) (string, error)
+
+// DeriveToken returns the stable session token the lnurl-server uses to hand back
+// the same LNURL each connection: hex(HMAC-SHA256(privKey, "lnurl-session")).
+func DeriveToken(privKey []byte) string {
+	mac := hmac.New(sha256.New, privKey)
+	mac.Write([]byte("lnurl-session"))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// Client maintains a persistent lnurl-server session that yields a stable,
+// amountless LNURL and bridges incoming pay requests to invoiceFor.
+type Client struct {
+	baseURL    string
+	token      string
+	invoiceFor InvoiceFunc
+
+	mu    sync.RWMutex
+	lnurl string
+}
+
+// New builds a client. privKey is the wallet private key bytes; the token is
+// derived from it so the same wallet always gets the same LNURL.
+func New(baseURL string, privKey []byte, invoiceFor InvoiceFunc) *Client {
+	return &Client{
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		token:      DeriveToken(privKey),
+		invoiceFor: invoiceFor,
+	}
+}
+
+// Lnurl returns the current active LNURL, or "" when no session is established.
+func (c *Client) Lnurl() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.lnurl
+}
+
+func (c *Client) setLnurl(v string) {
+	c.mu.Lock()
+	c.lnurl = v
+	c.mu.Unlock()
+}
+
+// Run opens the session and handles events until ctx is cancelled, reconnecting
+// with capped backoff on stream errors. Blocks; run it in a goroutine.
+func (c *Client) Run(ctx context.Context) {
+	backoff := time.Second
+	for ctx.Err() == nil {
+		err := c.connect(ctx)
+		if ctx.Err() != nil {
+			return
+		}
+		if err != nil {
+			time.Sleep(backoff)
+			if backoff < 30*time.Second {
+				backoff *= 2
+			}
+			continue
+		}
+		backoff = time.Second
+	}
+}
+
+func (c *Client) connect(ctx context.Context) error {
+	body := bytes.NewBufferString(fmt.Sprintf(`{"token":%q}`, c.token))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/lnurl/session", body)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("lnurl session open: status %d", resp.StatusCode)
+	}
+
+	var sessionID, authToken string
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	var event string
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case strings.HasPrefix(line, "event: "):
+			event = strings.TrimSpace(line[7:])
+		case strings.HasPrefix(line, "data: ") && event != "":
+			data := line[6:]
+			switch event {
+			case "session_created":
+				var d struct {
+					SessionId string `json:"sessionId"`
+					Token     string `json:"token"`
+					Lnurl     string `json:"lnurl"`
+				}
+				if err := json.Unmarshal([]byte(data), &d); err == nil {
+					sessionID, authToken = d.SessionId, d.Token
+					c.setLnurl(d.Lnurl)
+				}
+			case "invoice_request":
+				var d struct {
+					AmountMsat int64 `json:"amountMsat"`
+				}
+				if err := json.Unmarshal([]byte(data), &d); err == nil {
+					c.handleInvoiceRequest(ctx, sessionID, authToken, d.AmountMsat)
+				}
+			}
+			event = ""
+		}
+	}
+	c.setLnurl("")
+	return scanner.Err()
+}
+
+func (c *Client) handleInvoiceRequest(ctx context.Context, sessionID, token string, amountMsat int64) {
+	post := func(payload string) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+			fmt.Sprintf("%s/lnurl/session/%s/invoice", c.baseURL, sessionID),
+			bytes.NewBufferString(payload))
+		if err != nil {
+			return
+		}
+		req.Header.Set("Content-Type", "application/json")
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+		if resp, err := http.DefaultClient.Do(req); err == nil {
+			resp.Body.Close()
+		}
+	}
+	if amountMsat <= 0 {
+		post(`{"error":"invalid amount"}`)
+		return
+	}
+	pr, err := c.invoiceFor(ctx, uint64(amountMsat)/1000)
+	if err != nil || pr == "" {
+		reason := "failed to create invoice"
+		if err != nil {
+			reason = err.Error()
+		}
+		post(fmt.Sprintf(`{"error":%q}`, reason))
+		return
+	}
+	post(fmt.Sprintf(`{"pr":%q}`, pr))
+}

--- a/internal/lnurl/client.go
+++ b/internal/lnurl/client.go
@@ -63,23 +63,36 @@ func (c *Client) setLnurl(v string) {
 }
 
 // Run opens the session and handles events until ctx is cancelled, reconnecting
-// with capped backoff on stream errors. Blocks; run it in a goroutine.
+// with capped backoff after a stream error OR a clean close. Blocks; run it in a
+// goroutine.
 func (c *Client) Run(ctx context.Context) {
 	backoff := time.Second
 	for ctx.Err() == nil {
+		start := time.Now()
 		err := c.connect(ctx)
 		if ctx.Err() != nil {
 			return
 		}
 		if err != nil {
 			log.WithError(err).Warn("lnurl: session error, retrying")
-			time.Sleep(backoff)
-			if backoff < 30*time.Second {
-				backoff *= 2
-			}
-			continue
+		} else {
+			log.Debug("lnurl: session ended, reconnecting")
 		}
-		backoff = time.Second
+		// Back off before every reconnect, including a clean stream close: a
+		// server that returns 200 then EOFs immediately must not spin us in a
+		// tight loop. Reset the backoff only after a session that actually
+		// stayed up, so a flapping endpoint stays throttled.
+		if time.Since(start) > 30*time.Second {
+			backoff = time.Second
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+		if backoff < 30*time.Second {
+			backoff *= 2
+		}
 	}
 }
 

--- a/internal/lnurl/client_test.go
+++ b/internal/lnurl/client_test.go
@@ -105,3 +105,30 @@ func TestHandleInvoiceRequestRecoversFromPanic(t *testing.T) {
 	}()
 	c.handleInvoiceRequest(context.Background(), "sess", "tok", 50000)
 }
+
+func TestRunBackoffOnCleanClose(t *testing.T) {
+	// A server that returns 200 then closes the stream cleanly (no events) must
+	// not spin Run in a tight reconnect loop -- the backoff applies to clean
+	// closes too, not only errors.
+	var mu sync.Mutex
+	attempts := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		attempts++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK) // 200, then an immediate clean EOF
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, []byte{1, 2, 3, 4}, func(context.Context, uint64) (string, error) { return "", nil })
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	c.Run(ctx) // blocks until ctx is done
+
+	mu.Lock()
+	n := attempts
+	mu.Unlock()
+	if n > 5 {
+		t.Fatalf("clean-close reconnect not throttled: %d connect attempts in 2s", n)
+	}
+}

--- a/internal/lnurl/client_test.go
+++ b/internal/lnurl/client_test.go
@@ -90,3 +90,18 @@ func TestRunHandlesSessionAndInvoice(t *testing.T) {
 		t.Fatalf("posted pr = %q", gotPR)
 	}
 }
+
+func TestHandleInvoiceRequestRecoversFromPanic(t *testing.T) {
+	// A panicking invoiceFor (e.g. the historical nil-deref on an out-of-range
+	// amount) must be contained to the request, not propagate through the session
+	// goroutine and crash the daemon.
+	c := New("http://lnurl-server.invalid", []byte{1, 2, 3, 4}, func(context.Context, uint64) (string, error) {
+		panic("boom")
+	})
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("handleInvoiceRequest let a panic escape: %v", r)
+		}
+	}()
+	c.handleInvoiceRequest(context.Background(), "sess", "tok", 50000)
+}

--- a/internal/lnurl/client_test.go
+++ b/internal/lnurl/client_test.go
@@ -1,0 +1,92 @@
+package lnurl
+
+import (
+	"bufio"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestDeriveToken(t *testing.T) {
+	key := []byte{1, 2, 3, 4}
+	mac := hmac.New(sha256.New, key)
+	mac.Write([]byte("lnurl-session"))
+	want := hex.EncodeToString(mac.Sum(nil))
+
+	got := DeriveToken(key)
+	if got != want {
+		t.Fatalf("DeriveToken = %s, want %s", got, want)
+	}
+	if len(got) != 64 {
+		t.Fatalf("expected 64 hex chars, got %d", len(got))
+	}
+}
+
+func TestRunHandlesSessionAndInvoice(t *testing.T) {
+	var gotPR string
+	var mu sync.Mutex
+	done := make(chan struct{})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/lnurl/session" && r.Method == http.MethodPost:
+			fl, _ := w.(http.Flusher)
+			w.Header().Set("Content-Type", "text/event-stream")
+			fmt.Fprint(w, "event: session_created\ndata: {\"sessionId\":\"sess1\",\"token\":\"tok1\",\"lnurl\":\"lnurl1xyz\"}\n\n")
+			fl.Flush()
+			fmt.Fprint(w, "event: invoice_request\ndata: {\"amountMsat\":50000}\n\n")
+			fl.Flush()
+			<-r.Context().Done()
+		case r.URL.Path == "/lnurl/session/sess1/invoice" && r.Method == http.MethodPost:
+			var body struct {
+				Pr string `json:"pr"`
+			}
+			_ = json.NewDecoder(bufio.NewReader(r.Body)).Decode(&body)
+			mu.Lock()
+			gotPR = body.Pr
+			mu.Unlock()
+			if body.Pr != "" {
+				close(done)
+			}
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer srv.Close()
+
+	invoiceFor := func(ctx context.Context, sats uint64) (string, error) {
+		if sats != 50 {
+			t.Errorf("sats = %d, want 50 (50000 msat / 1000)", sats)
+		}
+		return "lnbcSIMULATED", nil
+	}
+	c := New(srv.URL, []byte{9, 9}, invoiceFor)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go c.Run(ctx)
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("invoice was not posted in time")
+	}
+
+	// The session is still active here (server holds the stream open), so the
+	// LNURL is set; check before cancelling to avoid the disconnect cleanup.
+	if c.Lnurl() != "lnurl1xyz" {
+		t.Fatalf("Lnurl = %q, want lnurl1xyz", c.Lnurl())
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if gotPR != "lnbcSIMULATED" {
+		t.Fatalf("posted pr = %q", gotPR)
+	}
+}

--- a/regtest-user.compose.yml
+++ b/regtest-user.compose.yml
@@ -20,6 +20,7 @@ services:
       - FULMINE_ESPLORA_URL=http://mempool_web/api
       - FULMINE_BOLTZ_URL=http://boltz:9001
       - FULMINE_BOLTZ_WS_URL=ws://boltz:9004
+      - FULMINE_LNURL_SERVER_URL=http://lnurl-server:3000
       - FULMINE_NO_MACAROONS=true
       - FULMINE_DISABLE_TELEMETRY=true
       - FULMINE_SWAP_TIMEOUT=120

--- a/web-e2e/regtest-web.compose.yml
+++ b/web-e2e/regtest-web.compose.yml
@@ -16,6 +16,7 @@ services:
       - FULMINE_ESPLORA_URL=http://mempool_web/api
       - FULMINE_BOLTZ_URL=http://boltz:9001
       - FULMINE_BOLTZ_WS_URL=ws://boltz:9004
+      - FULMINE_LNURL_SERVER_URL=http://lnurl-server:3000
       - FULMINE_NO_MACAROONS=true
       - FULMINE_DISABLE_TELEMETRY=true
       # env unlocker: the wallet auto-unlocks on restart, and the UI setup flow

--- a/web-e2e/tests/06-receive-lightning.spec.ts
+++ b/web-e2e/tests/06-receive-lightning.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from '@playwright/test';
+
+// Amountless LNURL receive: the daemon holds a persistent lnurl-server session
+// (started on unlock) that yields a stable LNURL, surfaced on the receive page.
+// Requires FULMINE_LNURL_SERVER_URL pointing at the stack's lnurl-server, which
+// regtest-web.compose.yml sets.
+test('receive page shows the amountless LNURL', async ({ page }) => {
+  await page.goto('/receive');
+  // The SSE session establishes shortly after unlock; give it room.
+  await expect(page.getByText('Lightning (any amount)')).toBeVisible({ timeout: 20000 });
+  await expect(page.getByText(/lnurl1/i)).toBeVisible();
+});

--- a/web-e2e/tests/06-receive-lightning.spec.ts
+++ b/web-e2e/tests/06-receive-lightning.spec.ts
@@ -5,8 +5,12 @@ import { test, expect } from '@playwright/test';
 // Requires FULMINE_LNURL_SERVER_URL pointing at the stack's lnurl-server, which
 // regtest-web.compose.yml sets.
 test('receive page shows the amountless LNURL', async ({ page }) => {
-  await page.goto('/receive');
-  // The SSE session establishes shortly after unlock; give it room.
-  await expect(page.getByText('Lightning (any amount)')).toBeVisible({ timeout: 20000 });
+  // CurrentLnurl() is rendered server-side and the page only reacts to
+  // TXS_ADDED, so a session that establishes after the initial load won't show
+  // up via a passive wait. Reload /receive until the LNURL row appears.
+  await expect(async () => {
+    await page.goto('/receive');
+    await expect(page.getByText('Lightning (any amount)')).toBeVisible({ timeout: 2000 });
+  }).toPass({ timeout: 30000 });
   await expect(page.getByText(/lnurl1/i)).toBeVisible();
 });


### PR DESCRIPTION
## Summary

Adds amountless Lightning receive to the receive page, matching the arkade wallet: fulmine holds a persistent lnurl-server session that yields a stable `LNURL1…`, surfaced as a "Lightning (any amount)" entry alongside the existing BIP21 / BTC / Ark addresses. Incoming LNURL-pay requests are bridged to `GetInvoice` (reverse swap LN→ARK), so a payer can send any amount.

## How it works

- **Config:** `LNURL_SERVER_URL` (e.g. `http://lnurl-server:3000`); empty disables the feature.
- **`internal/lnurl`:** a small client that derives a stable session token from the wallet key (`hex(HMAC-SHA256(privKey, "lnurl-session"))`, the same scheme the arkade wallet uses), opens the lnurl-server SSE session, and on each `invoice_request` calls back into the wallet to mint a BOLT11.
- **Service:** the receiver starts when the wallet comes online (both the `Setup` first-run path and the `UnlockNode` path) and stops on lock; `CurrentLnurl()` exposes the active LNURL to the web layer.
- **Receive page:** shows the LNURL as a copyable "Lightning (any amount)" line when configured.

The earlier draft also added a separate fixed-amount "Receive via Lightning" button, but `GetAddress` already inlines a fixed-amount invoice for an entered amount, so that was dropped as redundant.

## Testing

- **Unit:** token derivation (known-answer), the SSE session round-trip (mock server), a `LoadConfig` round-trip test that fails if `LNURL_SERVER_URL` isn't wired into `Config`, an invoice-handler panic-recovery test, and a reconnect-backoff test (a clean stream close must not busy-spin).
- **web-e2e:** `06-receive-lightning.spec.ts` asserts the amountless LNURL renders; `fulmine-web` is pointed at the stack's lnurl-server.
- **Manual (local regtest stack):** the receive page renders a real `LNURL1…`, and decoding it + hitting its callback for 50k sats returned a real `lnbcrt500u…` invoice (full reverse-swap round-trip). The out-of-range path was reproduced too: paying 1 sat (below Boltz's reverse minimum) now returns a clean `"amount is outside the supported range"` and the daemon stays up.

## Notes

End-to-end verification surfaced and fixed several wiring gaps between the env var and the rendered/payable LNURL: the config value wasn't read into `Config`; the fresh-wallet `Service` constructor dropped the field; the receiver started before the private key was set; and it was wired only into `UnlockNode`, which no-ops after `Setup` (the ArkClient is already unlocked) — so it now also starts from `Setup`, where the key is set. Each was a real defect, not a test artifact.

**Hardening from review (bug-hunt + CodeRabbit).** A few defects were found and fixed after the initial open, each with a regression test:
- **Out-of-range DoS (fixed + reproduced):** `GetInvoice` returns `(nil, nil)` when Boltz rejects the amount as out of swap limits; that was dereferenced, so any payer could crash the daemon by requesting an out-of-range amount. Now returns a clean error; reproduced against the live daemon.
- **Busy-spin reconnect:** a clean SSE close (200-then-EOF, e.g. a proxy idle timeout) made `Run` reconnect with no delay; backoff now applies to clean closes too.
- **Swap handler on Setup:** built in `Setup` so a freshly-created wallet can mint LNURL invoices without a lock/unlock cycle.
- Surfaced swallowed invoice-POST / malformed-payload errors, rejected sub-satoshi amounts instead of flooring them, and stopped relaying raw provider error strings to untrusted payers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `FULMINE_LNURL_SERVER_URL` configuration to enable amountless Lightning receive via lnurl-server.
  * Automatically starts LNURL receiving after unlock and stops when locking.
  * Receive page can now show a “Lightning (any amount)” address when available.
* **Bug Fixes**
  * Receive QR/contents now include the Lightning “any amount” lnurl when present.
* **Documentation**
  * Updated environment docs and README “Lightning & swaps” table.
* **Tests**
  * Added config, LNURL session/invoice unit tests, a concurrency/race regression test, and an E2E receive-lightning test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
