### PR TITLE
feat(receive): scannable QR for the amountless LNURL

### DIFF
--- a/internal/interface/web/handlers.go
+++ b/internal/interface/web/handlers.go
@@ -310,7 +310,18 @@ func (s *service) receiveQrCode(c *gin.Context) {
 	}
 	encoded := base64.StdEncoding.EncodeToString(png)
 
-	bodyContent := pages.ReceiveQrCodeContent(bip21, offchainAddr, boardingAddr, invoice, encoded, fmt.Sprintf("%d", sats), s.svc.CurrentLnurl())
+	// Pre-encode the LNURL QR too (when a session is active) so the page can toggle
+	// to it client-side without a round-trip. bech32 uppercase keeps the QR in the
+	// denser alphanumeric mode and decodes to the same LNURL as the text below it.
+	lnurl := s.svc.CurrentLnurl()
+	var lnurlQr string
+	if lnurl != "" {
+		if lnPng, lnErr := qrcode.Encode(strings.ToUpper(lnurl), qrcode.Medium, 256); lnErr == nil {
+			lnurlQr = base64.StdEncoding.EncodeToString(lnPng)
+		}
+	}
+
+	bodyContent := pages.ReceiveQrCodeContent(bip21, offchainAddr, boardingAddr, invoice, encoded, fmt.Sprintf("%d", sats), lnurl, lnurlQr)
 	s.pageViewHandler(bodyContent, c)
 }
 
@@ -338,30 +349,6 @@ func (s *service) receiveSwap(c *gin.Context) {
 	}
 	encoded := base64.StdEncoding.EncodeToString(png)
 	bodyContent := pages.ReceiveSwapContent(chainSwap.UserBtcLockupAddress, fmt.Sprintf("%d", sats), encoded)
-	s.pageViewHandler(bodyContent, c)
-}
-
-// receiveLnurlQr renders the active amountless LNURL as a scannable QR.
-func (s *service) receiveLnurlQr(c *gin.Context) {
-	if s.redirectedBecauseWalletIsLocked(c) {
-		return
-	}
-	lnurl := s.svc.CurrentLnurl()
-	if lnurl == "" {
-		toast := components.Toast("no Lightning address available yet", true)
-		toastHandler(toast, c)
-		return
-	}
-	// bech32 uppercase encodes in the QR alphanumeric mode, yielding a denser,
-	// easier-to-scan code; it decodes to the same LNURL as the displayed text.
-	png, err := qrcode.Encode(strings.ToUpper(lnurl), qrcode.Medium, 256)
-	if err != nil {
-		// nolint:all
-		c.AbortWithError(http.StatusInternalServerError, err)
-		return
-	}
-	encoded := base64.StdEncoding.EncodeToString(png)
-	bodyContent := pages.ReceiveLnurlQrContent(lnurl, encoded)
 	s.pageViewHandler(bodyContent, c)
 }
 

--- a/internal/interface/web/handlers.go
+++ b/internal/interface/web/handlers.go
@@ -341,6 +341,30 @@ func (s *service) receiveSwap(c *gin.Context) {
 	s.pageViewHandler(bodyContent, c)
 }
 
+// receiveLnurlQr renders the active amountless LNURL as a scannable QR.
+func (s *service) receiveLnurlQr(c *gin.Context) {
+	if s.redirectedBecauseWalletIsLocked(c) {
+		return
+	}
+	lnurl := s.svc.CurrentLnurl()
+	if lnurl == "" {
+		toast := components.Toast("no Lightning address available yet", true)
+		toastHandler(toast, c)
+		return
+	}
+	// bech32 uppercase encodes in the QR alphanumeric mode, yielding a denser,
+	// easier-to-scan code; it decodes to the same LNURL as the displayed text.
+	png, err := qrcode.Encode(strings.ToUpper(lnurl), qrcode.Medium, 256)
+	if err != nil {
+		// nolint:all
+		c.AbortWithError(http.StatusInternalServerError, err)
+		return
+	}
+	encoded := base64.StdEncoding.EncodeToString(png)
+	bodyContent := pages.ReceiveLnurlQrContent(lnurl, encoded)
+	s.pageViewHandler(bodyContent, c)
+}
+
 func (s *service) receiveSuccess(c *gin.Context) {
 	bip21 := c.PostForm(("bip21"))
 

--- a/internal/interface/web/handlers.go
+++ b/internal/interface/web/handlers.go
@@ -308,7 +308,7 @@ func (s *service) receiveQrCode(c *gin.Context) {
 	if err != nil {
 		return
 	}
-	encoded := base64.StdEncoding.EncodeToString(png)
+	bip21Qr := base64.StdEncoding.EncodeToString(png)
 
 	// Pre-encode the LNURL QR too (when a session is active) so the page can toggle
 	// to it client-side without a round-trip. bech32 uppercase keeps the QR in the
@@ -321,7 +321,7 @@ func (s *service) receiveQrCode(c *gin.Context) {
 		}
 	}
 
-	bodyContent := pages.ReceiveQrCodeContent(bip21, offchainAddr, boardingAddr, invoice, encoded, fmt.Sprintf("%d", sats), lnurl, lnurlQr)
+	bodyContent := pages.ReceiveQrCodeContent(bip21, offchainAddr, boardingAddr, invoice, bip21Qr, fmt.Sprintf("%d", sats), lnurl, lnurlQr)
 	s.pageViewHandler(bodyContent, c)
 }
 

--- a/internal/interface/web/server.go
+++ b/internal/interface/web/server.go
@@ -128,7 +128,6 @@ func NewService(
 	svc.POST("/receive/preview", svc.receiveQrCode)
 	svc.POST("/receive/success", svc.receiveSuccess)
 	svc.POST("/receive/swap", svc.receiveSwap)
-	svc.POST("/receive/lnurl-qr", svc.receiveLnurlQr)
 	svc.POST("/send/preview", svc.sendPreview)
 	svc.POST("/send/confirm", svc.sendConfirm)
 

--- a/internal/interface/web/server.go
+++ b/internal/interface/web/server.go
@@ -128,6 +128,7 @@ func NewService(
 	svc.POST("/receive/preview", svc.receiveQrCode)
 	svc.POST("/receive/success", svc.receiveSuccess)
 	svc.POST("/receive/swap", svc.receiveSwap)
+	svc.POST("/receive/lnurl-qr", svc.receiveLnurlQr)
 	svc.POST("/send/preview", svc.sendPreview)
 	svc.POST("/send/confirm", svc.sendConfirm)
 

--- a/internal/interface/web/templates/pages/receive.templ
+++ b/internal/interface/web/templates/pages/receive.templ
@@ -36,7 +36,7 @@ templ ReceiveEditContent() {
 	</script>
 }
 
-templ ReceiveQrCodeContent(bip21, offchainAddr, boardingAddr, invoice, encoded, sats, lnurl string) {
+templ ReceiveQrCodeContent(bip21, offchainAddr, boardingAddr, invoice, encoded, sats, lnurl, lnurlQr string) {
 	<form id="success" hx-post="/receive/success" hx-ext="sse" sse-connect="/events" hx-trigger="sse:TXS_ADDED">
 	  @components.DesktopHeader()
 	  <input class="hidden" id="submitButton" type="submit"/>
@@ -46,7 +46,10 @@ templ ReceiveQrCodeContent(bip21, offchainAddr, boardingAddr, invoice, encoded, 
 	    @components.Header("Receive")
       <div class="flex flex-col justify-center items-center gap-2">
 	  	  <div class="h-64 mb-8">
-            <img src={"data:image/png;base64," + encoded} alt="qrcode for receive address" title={bip21}>
+            <img id="bip21Qr" src={"data:image/png;base64," + encoded} alt="qrcode for receive address" title={bip21}>
+            if len(lnurlQr) > 0 {
+              <img id="lnurlQr" class="hidden" src={"data:image/png;base64," + lnurlQr} alt="qrcode for Lightning address" title={lnurl}>
+            }
 		  </div>
 				<div class="flex flex-col gap-2 w-11/12 max-w-[600px]">
 					if len(bip21) > 0 {
@@ -76,14 +79,25 @@ templ ReceiveQrCodeContent(bip21, offchainAddr, boardingAddr, invoice, encoded, 
 					<span class="ml-2">Receive via BTC</span>
 				</button>
 			}
-			if len(lnurl) > 0 {
-				<button type="button" class="button md:w-auto" hx-post="/receive/lnurl-qr" hx-target="#success" hx-swap="outerHTML">
-					<span class="ml-2">Lightning QR</span>
+			if len(lnurlQr) > 0 {
+				<button type="button" class="button md:w-auto" onclick="toggleLnurlQr()">
+					<span id="qrToggleLabel" class="ml-2">Lightning QR</span>
 				</button>
 			}
 	    </div>
 	  </div>
 	</form>
+	<script>
+	  function toggleLnurlQr() {
+			const bip = document.getElementById('bip21Qr')
+			const ln = document.getElementById('lnurlQr')
+			if (!ln) return
+			const showLnurl = ln.classList.contains('hidden')
+			ln.classList.toggle('hidden', !showLnurl)
+			bip.classList.toggle('hidden', showLnurl)
+			document.getElementById('qrToggleLabel').textContent = showLnurl ? 'Bitcoin QR' : 'Lightning QR'
+		}
+	</script>
 }
 
 templ ReceiveSuccessContent(offchainAddr, sats string) {
@@ -114,29 +128,6 @@ templ ReceiveSwapContent(lockupAddr, amount, encoded string) {
 	      </div>
 	      <div class="flex flex-col gap-2 w-11/12 max-w-[600px]">
 	        @addressLine("BTC lockup address", lockupAddr)
-	      </div>
-	    </div>
-	    <div class="flex flex-col md:flex-row justify-start gap-4 mt-10 mb-2">
-	      <a class="button md:w-auto" onclick="redirect('/receive')">
-	        <span class="ml-2">Done</span>
-	      </a>
-	    </div>
-	  </div>
-	</div>
-}
-
-templ ReceiveLnurlQrContent(lnurl, encoded string) {
-	@components.DesktopHeader()
-	<div id="receiveBody">
-	  <div class="p-3 flex flex-col justify-between rounded-lg h-screen md:h-auto md:bg-desktopbg">
-	    @components.Header("Lightning")
-	    <div class="flex flex-col justify-center items-center gap-2">
-	      <p class="mt-2 text-center text-white/50 w-11/12 max-w-[600px]">Scan to pay any amount over Lightning. Funds arrive in your Ark balance once the payment settles.</p>
-	      <div class="h-64 my-6">
-	        <img src={"data:image/png;base64," + encoded} alt="qrcode for Lightning address" title={lnurl}>
-	      </div>
-	      <div class="flex flex-col gap-2 w-11/12 max-w-[600px]">
-	        @addressLine("Lightning (any amount)", lnurl)
 	      </div>
 	    </div>
 	    <div class="flex flex-col md:flex-row justify-start gap-4 mt-10 mb-2">

--- a/internal/interface/web/templates/pages/receive.templ
+++ b/internal/interface/web/templates/pages/receive.templ
@@ -36,7 +36,7 @@ templ ReceiveEditContent() {
 	</script>
 }
 
-templ ReceiveQrCodeContent(bip21, offchainAddr, boardingAddr, invoice, encoded, sats, lnurl, lnurlQr string) {
+templ ReceiveQrCodeContent(bip21, offchainAddr, boardingAddr, invoice, bip21Qr, sats, lnurl, lnurlQr string) {
 	<form id="success" hx-post="/receive/success" hx-ext="sse" sse-connect="/events" hx-trigger="sse:TXS_ADDED">
 	  @components.DesktopHeader()
 	  <input class="hidden" id="submitButton" type="submit"/>
@@ -46,7 +46,7 @@ templ ReceiveQrCodeContent(bip21, offchainAddr, boardingAddr, invoice, encoded, 
 	    @components.Header("Receive")
       <div class="flex flex-col justify-center items-center gap-2">
 	  	  <div class="h-64 mb-8">
-            <img id="bip21Qr" src={"data:image/png;base64," + encoded} alt="qrcode for receive address" title={bip21}>
+            <img id="bip21Qr" src={"data:image/png;base64," + bip21Qr} alt="qrcode for receive address" title={bip21}>
             if len(lnurlQr) > 0 {
               <img id="lnurlQr" class="hidden" src={"data:image/png;base64," + lnurlQr} alt="qrcode for Lightning address" title={lnurl}>
             }

--- a/internal/interface/web/templates/pages/receive.templ
+++ b/internal/interface/web/templates/pages/receive.templ
@@ -76,6 +76,11 @@ templ ReceiveQrCodeContent(bip21, offchainAddr, boardingAddr, invoice, encoded, 
 					<span class="ml-2">Receive via BTC</span>
 				</button>
 			}
+			if len(lnurl) > 0 {
+				<button type="button" class="button md:w-auto" hx-post="/receive/lnurl-qr" hx-target="#success" hx-swap="outerHTML">
+					<span class="ml-2">Lightning QR</span>
+				</button>
+			}
 	    </div>
 	  </div>
 	</form>
@@ -109,6 +114,29 @@ templ ReceiveSwapContent(lockupAddr, amount, encoded string) {
 	      </div>
 	      <div class="flex flex-col gap-2 w-11/12 max-w-[600px]">
 	        @addressLine("BTC lockup address", lockupAddr)
+	      </div>
+	    </div>
+	    <div class="flex flex-col md:flex-row justify-start gap-4 mt-10 mb-2">
+	      <a class="button md:w-auto" onclick="redirect('/receive')">
+	        <span class="ml-2">Done</span>
+	      </a>
+	    </div>
+	  </div>
+	</div>
+}
+
+templ ReceiveLnurlQrContent(lnurl, encoded string) {
+	@components.DesktopHeader()
+	<div id="receiveBody">
+	  <div class="p-3 flex flex-col justify-between rounded-lg h-screen md:h-auto md:bg-desktopbg">
+	    @components.Header("Lightning")
+	    <div class="flex flex-col justify-center items-center gap-2">
+	      <p class="mt-2 text-center text-white/50 w-11/12 max-w-[600px]">Scan to pay any amount over Lightning. Funds arrive in your Ark balance once the payment settles.</p>
+	      <div class="h-64 my-6">
+	        <img src={"data:image/png;base64," + encoded} alt="qrcode for Lightning address" title={lnurl}>
+	      </div>
+	      <div class="flex flex-col gap-2 w-11/12 max-w-[600px]">
+	        @addressLine("Lightning (any amount)", lnurl)
 	      </div>
 	    </div>
 	    <div class="flex flex-col md:flex-row justify-start gap-4 mt-10 mb-2">

--- a/internal/interface/web/templates/pages/receive_templ.go
+++ b/internal/interface/web/templates/pages/receive_templ.go
@@ -268,12 +268,18 @@ func ReceiveQrCodeContent(bip21, offchainAddr, boardingAddr, invoice, encoded, s
 			return templ_7745c5c3_Err
 		}
 		if sats != "0" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<button type=\"button\" class=\"button md:w-auto\" hx-post=\"/receive/swap\" hx-include=\"[name='sats']\" hx-target=\"#success\" hx-swap=\"outerHTML\"><span class=\"ml-2\">Receive via BTC</span></button>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<button type=\"button\" class=\"button md:w-auto\" hx-post=\"/receive/swap\" hx-include=\"[name='sats']\" hx-target=\"#success\" hx-swap=\"outerHTML\"><span class=\"ml-2\">Receive via BTC</span></button> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</div></div></form>")
+		if len(lnurl) > 0 {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "<button type=\"button\" class=\"button md:w-auto\" hx-post=\"/receive/lnurl-qr\" hx-target=\"#success\" hx-swap=\"outerHTML\"><span class=\"ml-2\">Lightning QR</span></button>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "</div></div></form>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -306,7 +312,7 @@ func ReceiveSuccessContent(offchainAddr, sats string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<div class=\"p-3 flex flex-col justify-between rounded-lg h-screen md:h-auto md:bg-desktopbg\"><div class=\"flex flex-col items-center\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<div class=\"p-3 flex flex-col justify-between rounded-lg h-screen md:h-auto md:bg-desktopbg\"><div class=\"flex flex-col items-center\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -318,46 +324,46 @@ func ReceiveSuccessContent(offchainAddr, sats string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<p class=\"mt-8\">Received successfully</p><p class=\"mt-8 text-3xl cryptoAmount\" sats=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "<p class=\"mt-8\">Received successfully</p><p class=\"mt-8 text-3xl cryptoAmount\" sats=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var11 string
 		templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(sats)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 91, Col: 51}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 96, Col: 51}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var12 string
 		templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(sats)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 91, Col: 58}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 96, Col: 58}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, " SATS</p><div class=\"flex mt-8 w-64 gap-2\"><p class=\"text-white/50\">to</p><p class=\"overflow-hidden text-ellipsis whitespace-nowrap\" id=\"recvAddress\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, " SATS</p><div class=\"flex mt-8 w-64 gap-2\"><p class=\"text-white/50\">to</p><p class=\"overflow-hidden text-ellipsis whitespace-nowrap\" id=\"recvAddress\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var13 string
 		templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(offchainAddr)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 94, Col: 93}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 99, Col: 93}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "</p>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "</p>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -365,7 +371,7 @@ func ReceiveSuccessContent(offchainAddr, sats string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "</div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "</div></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -398,7 +404,7 @@ func ReceiveSwapContent(lockupAddr, amount, encoded string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "<div id=\"receiveBody\"><div class=\"p-3 flex flex-col justify-between rounded-lg h-screen md:h-auto md:bg-desktopbg\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<div id=\"receiveBody\"><div class=\"p-3 flex flex-col justify-between rounded-lg h-screen md:h-auto md:bg-desktopbg\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -406,59 +412,59 @@ func ReceiveSwapContent(lockupAddr, amount, encoded string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<div class=\"flex flex-col justify-center items-center gap-2\"><p class=\"mt-2 text-center text-white/50 w-11/12 max-w-[600px]\">Send <span class=\"cryptoAmount\" sats=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "<div class=\"flex flex-col justify-center items-center gap-2\"><p class=\"mt-2 text-center text-white/50 w-11/12 max-w-[600px]\">Send <span class=\"cryptoAmount\" sats=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var15 string
 		templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(amount)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 106, Col: 115}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 111, Col: 115}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var16 string
 		templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(amount)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 106, Col: 124}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 111, Col: 124}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, " SATS</span> of on-chain BTC to the address below. Your Ark balance updates once the swap confirms.</p><div class=\"h-64 my-6\"><img src=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, " SATS</span> of on-chain BTC to the address below. Your Ark balance updates once the swap confirms.</p><div class=\"h-64 my-6\"><img src=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var17 string
 		templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs("data:image/png;base64," + encoded)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 108, Col: 53}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 113, Col: 53}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "\" alt=\"qrcode for BTC lockup address\" title=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "\" alt=\"qrcode for BTC lockup address\" title=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var18 string
 		templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(lockupAddr)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 108, Col: 108}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 113, Col: 108}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "\"></div><div class=\"flex flex-col gap-2 w-11/12 max-w-[600px]\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "\"></div><div class=\"flex flex-col gap-2 w-11/12 max-w-[600px]\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -466,7 +472,82 @@ func ReceiveSwapContent(lockupAddr, amount, encoded string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "</div></div><div class=\"flex flex-col md:flex-row justify-start gap-4 mt-10 mb-2\"><a class=\"button md:w-auto\" onclick=\"redirect('/receive')\"><span class=\"ml-2\">Done</span></a></div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "</div></div><div class=\"flex flex-col md:flex-row justify-start gap-4 mt-10 mb-2\"><a class=\"button md:w-auto\" onclick=\"redirect('/receive')\"><span class=\"ml-2\">Done</span></a></div></div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+func ReceiveLnurlQrContent(lnurl, encoded string) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var19 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var19 == nil {
+			templ_7745c5c3_Var19 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = components.DesktopHeader().Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "<div id=\"receiveBody\"><div class=\"p-3 flex flex-col justify-between rounded-lg h-screen md:h-auto md:bg-desktopbg\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = components.Header("Lightning").Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "<div class=\"flex flex-col justify-center items-center gap-2\"><p class=\"mt-2 text-center text-white/50 w-11/12 max-w-[600px]\">Scan to pay any amount over Lightning. Funds arrive in your Ark balance once the payment settles.</p><div class=\"h-64 my-6\"><img src=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var20 string
+		templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs("data:image/png;base64," + encoded)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 136, Col: 53}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "\" alt=\"qrcode for Lightning address\" title=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var21 string
+		templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(lnurl)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 136, Col: 102}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "\"></div><div class=\"flex flex-col gap-2 w-11/12 max-w-[600px]\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = addressLine("Lightning (any amount)", lnurl).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "</div></div><div class=\"flex flex-col md:flex-row justify-start gap-4 mt-10 mb-2\"><a class=\"button md:w-auto\" onclick=\"redirect('/receive')\"><span class=\"ml-2\">Done</span></a></div></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/interface/web/templates/pages/receive_templ.go
+++ b/internal/interface/web/templates/pages/receive_templ.go
@@ -132,7 +132,7 @@ func ReceiveEditContent() templ.Component {
 	})
 }
 
-func ReceiveQrCodeContent(bip21, offchainAddr, boardingAddr, invoice, encoded, sats, lnurl string) templ.Component {
+func ReceiveQrCodeContent(bip21, offchainAddr, boardingAddr, invoice, encoded, sats, lnurl, lnurlQr string) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -195,14 +195,14 @@ func ReceiveQrCodeContent(bip21, offchainAddr, boardingAddr, invoice, encoded, s
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<div class=\"flex flex-col justify-center items-center gap-2\"><div class=\"h-64 mb-8\"><img src=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<div class=\"flex flex-col justify-center items-center gap-2\"><div class=\"h-64 mb-8\"><img id=\"bip21Qr\" src=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var8 string
 		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs("data:image/png;base64," + encoded)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 49, Col: 56}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 49, Col: 69}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 		if templ_7745c5c3_Err != nil {
@@ -215,13 +215,49 @@ func ReceiveQrCodeContent(bip21, offchainAddr, boardingAddr, invoice, encoded, s
 		var templ_7745c5c3_Var9 string
 		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(bip21)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 49, Col: 103}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 49, Col: 116}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "\"></div><div class=\"flex flex-col gap-2 w-11/12 max-w-[600px]\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "\"> ")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if len(lnurlQr) > 0 {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "<img id=\"lnurlQr\" class=\"hidden\" src=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var10 string
+			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs("data:image/png;base64," + lnurlQr)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 51, Col: 86}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "\" alt=\"qrcode for Lightning address\" title=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var11 string
+			templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(lnurl)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 51, Col: 135}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</div><div class=\"flex flex-col gap-2 w-11/12 max-w-[600px]\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -255,7 +291,7 @@ func ReceiveQrCodeContent(bip21, offchainAddr, boardingAddr, invoice, encoded, s
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</div></div><div class=\"flex flex-col md:flex-row justify-start gap-4 mt-10 mb-2\"><a class=\"button md:w-auto\" onclick=\"redirect('/receive/edit')\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "</div></div><div class=\"flex flex-col md:flex-row justify-start gap-4 mt-10 mb-2\"><a class=\"button md:w-auto\" onclick=\"redirect('/receive/edit')\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -263,23 +299,23 @@ func ReceiveQrCodeContent(bip21, offchainAddr, boardingAddr, invoice, encoded, s
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<span class=\"ml-2\">Add amount</span></a> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<span class=\"ml-2\">Add amount</span></a> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if sats != "0" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<button type=\"button\" class=\"button md:w-auto\" hx-post=\"/receive/swap\" hx-include=\"[name='sats']\" hx-target=\"#success\" hx-swap=\"outerHTML\"><span class=\"ml-2\">Receive via BTC</span></button> ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "<button type=\"button\" class=\"button md:w-auto\" hx-post=\"/receive/swap\" hx-include=\"[name='sats']\" hx-target=\"#success\" hx-swap=\"outerHTML\"><span class=\"ml-2\">Receive via BTC</span></button> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		if len(lnurl) > 0 {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "<button type=\"button\" class=\"button md:w-auto\" hx-post=\"/receive/lnurl-qr\" hx-target=\"#success\" hx-swap=\"outerHTML\"><span class=\"ml-2\">Lightning QR</span></button>")
+		if len(lnurlQr) > 0 {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "<button type=\"button\" class=\"button md:w-auto\" onclick=\"toggleLnurlQr()\"><span id=\"qrToggleLabel\" class=\"ml-2\">Lightning QR</span></button>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "</div></div></form>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "</div></div></form><script>\r\n\t  function toggleLnurlQr() {\r\n\t\t\tconst bip = document.getElementById('bip21Qr')\r\n\t\t\tconst ln = document.getElementById('lnurlQr')\r\n\t\t\tif (!ln) return\r\n\t\t\tconst showLnurl = ln.classList.contains('hidden')\r\n\t\t\tln.classList.toggle('hidden', !showLnurl)\r\n\t\t\tbip.classList.toggle('hidden', showLnurl)\r\n\t\t\tdocument.getElementById('qrToggleLabel').textContent = showLnurl ? 'Bitcoin QR' : 'Lightning QR'\r\n\t\t}\r\n\t</script>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -303,16 +339,16 @@ func ReceiveSuccessContent(offchainAddr, sats string) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var10 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var10 == nil {
-			templ_7745c5c3_Var10 = templ.NopComponent
+		templ_7745c5c3_Var12 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var12 == nil {
+			templ_7745c5c3_Var12 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		templ_7745c5c3_Err = components.DesktopHeader().Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<div class=\"p-3 flex flex-col justify-between rounded-lg h-screen md:h-auto md:bg-desktopbg\"><div class=\"flex flex-col items-center\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "<div class=\"p-3 flex flex-col justify-between rounded-lg h-screen md:h-auto md:bg-desktopbg\"><div class=\"flex flex-col items-center\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -324,46 +360,46 @@ func ReceiveSuccessContent(offchainAddr, sats string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "<p class=\"mt-8\">Received successfully</p><p class=\"mt-8 text-3xl cryptoAmount\" sats=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var11 string
-		templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(sats)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 96, Col: 51}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "\">")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var12 string
-		templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(sats)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 96, Col: 58}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, " SATS</p><div class=\"flex mt-8 w-64 gap-2\"><p class=\"text-white/50\">to</p><p class=\"overflow-hidden text-ellipsis whitespace-nowrap\" id=\"recvAddress\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "<p class=\"mt-8\">Received successfully</p><p class=\"mt-8 text-3xl cryptoAmount\" sats=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var13 string
-		templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(offchainAddr)
+		templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(sats)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 99, Col: 93}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 110, Col: 51}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "</p>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var14 string
+		templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(sats)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 110, Col: 58}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, " SATS</p><div class=\"flex mt-8 w-64 gap-2\"><p class=\"text-white/50\">to</p><p class=\"overflow-hidden text-ellipsis whitespace-nowrap\" id=\"recvAddress\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var15 string
+		templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(offchainAddr)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 113, Col: 93}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "</p>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -371,7 +407,7 @@ func ReceiveSuccessContent(offchainAddr, sats string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "</div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "</div></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -395,16 +431,16 @@ func ReceiveSwapContent(lockupAddr, amount, encoded string) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var14 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var14 == nil {
-			templ_7745c5c3_Var14 = templ.NopComponent
+		templ_7745c5c3_Var16 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var16 == nil {
+			templ_7745c5c3_Var16 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		templ_7745c5c3_Err = components.DesktopHeader().Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<div id=\"receiveBody\"><div class=\"p-3 flex flex-col justify-between rounded-lg h-screen md:h-auto md:bg-desktopbg\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "<div id=\"receiveBody\"><div class=\"p-3 flex flex-col justify-between rounded-lg h-screen md:h-auto md:bg-desktopbg\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -412,59 +448,59 @@ func ReceiveSwapContent(lockupAddr, amount, encoded string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "<div class=\"flex flex-col justify-center items-center gap-2\"><p class=\"mt-2 text-center text-white/50 w-11/12 max-w-[600px]\">Send <span class=\"cryptoAmount\" sats=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var15 string
-		templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(amount)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 111, Col: 115}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "\">")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var16 string
-		templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(amount)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 111, Col: 124}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, " SATS</span> of on-chain BTC to the address below. Your Ark balance updates once the swap confirms.</p><div class=\"h-64 my-6\"><img src=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "<div class=\"flex flex-col justify-center items-center gap-2\"><p class=\"mt-2 text-center text-white/50 w-11/12 max-w-[600px]\">Send <span class=\"cryptoAmount\" sats=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var17 string
-		templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs("data:image/png;base64," + encoded)
+		templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(amount)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 113, Col: 53}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 125, Col: 115}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "\" alt=\"qrcode for BTC lockup address\" title=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var18 string
-		templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(lockupAddr)
+		templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(amount)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 113, Col: 108}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 125, Col: 124}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "\"></div><div class=\"flex flex-col gap-2 w-11/12 max-w-[600px]\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, " SATS</span> of on-chain BTC to the address below. Your Ark balance updates once the swap confirms.</p><div class=\"h-64 my-6\"><img src=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var19 string
+		templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs("data:image/png;base64," + encoded)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 127, Col: 53}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "\" alt=\"qrcode for BTC lockup address\" title=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var20 string
+		templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(lockupAddr)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 127, Col: 108}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "\"></div><div class=\"flex flex-col gap-2 w-11/12 max-w-[600px]\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -472,82 +508,7 @@ func ReceiveSwapContent(lockupAddr, amount, encoded string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "</div></div><div class=\"flex flex-col md:flex-row justify-start gap-4 mt-10 mb-2\"><a class=\"button md:w-auto\" onclick=\"redirect('/receive')\"><span class=\"ml-2\">Done</span></a></div></div></div>")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		return nil
-	})
-}
-
-func ReceiveLnurlQrContent(lnurl, encoded string) templ.Component {
-	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
-		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
-		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
-			return templ_7745c5c3_CtxErr
-		}
-		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
-		if !templ_7745c5c3_IsBuffer {
-			defer func() {
-				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
-				if templ_7745c5c3_Err == nil {
-					templ_7745c5c3_Err = templ_7745c5c3_BufErr
-				}
-			}()
-		}
-		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var19 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var19 == nil {
-			templ_7745c5c3_Var19 = templ.NopComponent
-		}
-		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = components.DesktopHeader().Render(ctx, templ_7745c5c3_Buffer)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "<div id=\"receiveBody\"><div class=\"p-3 flex flex-col justify-between rounded-lg h-screen md:h-auto md:bg-desktopbg\">")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = components.Header("Lightning").Render(ctx, templ_7745c5c3_Buffer)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "<div class=\"flex flex-col justify-center items-center gap-2\"><p class=\"mt-2 text-center text-white/50 w-11/12 max-w-[600px]\">Scan to pay any amount over Lightning. Funds arrive in your Ark balance once the payment settles.</p><div class=\"h-64 my-6\"><img src=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var20 string
-		templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs("data:image/png;base64," + encoded)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 136, Col: 53}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "\" alt=\"qrcode for Lightning address\" title=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var21 string
-		templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(lnurl)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 136, Col: 102}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "\"></div><div class=\"flex flex-col gap-2 w-11/12 max-w-[600px]\">")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = addressLine("Lightning (any amount)", lnurl).Render(ctx, templ_7745c5c3_Buffer)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "</div></div><div class=\"flex flex-col md:flex-row justify-start gap-4 mt-10 mb-2\"><a class=\"button md:w-auto\" onclick=\"redirect('/receive')\"><span class=\"ml-2\">Done</span></a></div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "</div></div><div class=\"flex flex-col md:flex-row justify-start gap-4 mt-10 mb-2\"><a class=\"button md:w-auto\" onclick=\"redirect('/receive')\"><span class=\"ml-2\">Done</span></a></div></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/interface/web/templates/pages/receive_templ.go
+++ b/internal/interface/web/templates/pages/receive_templ.go
@@ -132,7 +132,7 @@ func ReceiveEditContent() templ.Component {
 	})
 }
 
-func ReceiveQrCodeContent(bip21, offchainAddr, boardingAddr, invoice, encoded, sats, lnurl, lnurlQr string) templ.Component {
+func ReceiveQrCodeContent(bip21, offchainAddr, boardingAddr, invoice, bip21Qr, sats, lnurl, lnurlQr string) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -200,7 +200,7 @@ func ReceiveQrCodeContent(bip21, offchainAddr, boardingAddr, invoice, encoded, s
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var8 string
-		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs("data:image/png;base64," + encoded)
+		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs("data:image/png;base64," + bip21Qr)
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/interface/web/templates/pages/receive.templ`, Line: 49, Col: 69}
 		}

--- a/web-e2e/tests/07-receive-lnurl-qr.spec.ts
+++ b/web-e2e/tests/07-receive-lnurl-qr.spec.ts
@@ -1,20 +1,21 @@
 import { test, expect } from '@playwright/test';
 
-// LNURL QR: when an amountless LNURL session is active, the receive page offers
-// a "Lightning QR" button; clicking it renders the LNURL as a scannable QR.
-// Requires the lnurl-server session (same setup as 06-receive-lightning).
-test('receive page shows a scannable QR for the amountless LNURL', async ({ page }) => {
+// LNURL QR: the receive page pre-renders the amountless LNURL as a QR (hidden)
+// and a "Lightning QR" button toggles it client-side — no extra request, no
+// separate endpoint. Requires the lnurl-server session (same setup as 06).
+test('receive page toggles to a scannable QR for the amountless LNURL', async ({ page }) => {
   // Reload /receive until the LNURL session is established (see 06).
   await expect(async () => {
     await page.goto('/receive');
     await expect(page.getByText('Lightning (any amount)')).toBeVisible({ timeout: 2000 });
   }).toPass({ timeout: 30000 });
 
-  const qrButton = page.getByRole('button', { name: 'Lightning QR' });
-  await expect(qrButton).toBeVisible();
-  await qrButton.click();
+  // The LNURL QR is pre-rendered but hidden until toggled.
+  const lnurlQr = page.locator('#lnurlQr');
+  await expect(lnurlQr).toBeHidden();
 
-  // The QR view: a QR image for the Lightning address + the lnurl1… text.
-  await expect(page.locator('img[alt="qrcode for Lightning address"]')).toBeVisible();
-  await expect(page.getByText(/lnurl1/i)).toBeVisible();
+  await page.getByRole('button', { name: 'Lightning QR' }).click();
+
+  await expect(lnurlQr).toBeVisible();
+  await expect(page.locator('#bip21Qr')).toBeHidden();
 });

--- a/web-e2e/tests/07-receive-lnurl-qr.spec.ts
+++ b/web-e2e/tests/07-receive-lnurl-qr.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+
+// LNURL QR: when an amountless LNURL session is active, the receive page offers
+// a "Lightning QR" button; clicking it renders the LNURL as a scannable QR.
+// Requires the lnurl-server session (same setup as 06-receive-lightning).
+test('receive page shows a scannable QR for the amountless LNURL', async ({ page }) => {
+  // Reload /receive until the LNURL session is established (see 06).
+  await expect(async () => {
+    await page.goto('/receive');
+    await expect(page.getByText('Lightning (any amount)')).toBeVisible({ timeout: 2000 });
+  }).toPass({ timeout: 30000 });
+
+  const qrButton = page.getByRole('button', { name: 'Lightning QR' });
+  await expect(qrButton).toBeVisible();
+  await qrButton.click();
+
+  // The QR view: a QR image for the Lightning address + the lnurl1… text.
+  await expect(page.locator('img[alt="qrcode for Lightning address"]')).toBeVisible();
+  await expect(page.getByText(/lnurl1/i)).toBeVisible();
+});


### PR DESCRIPTION
## Summary

Adds a scannable QR for the amountless LNURL on the receive page. #444 surfaces the `lnurl1…` string as a copyable line, but there's no way to *scan* it — so a payer with a Lightning wallet has to copy-paste. This adds a "Lightning QR" toggle, matching normal wallet receive UX.

> Stacked on #444. Base it on `feat/lnurl-receive`; GitHub retargets to `master` once #444 merges.

## How it works

`receiveQrCode` already has the LNURL (`CurrentLnurl()`) and already encodes the BIP21 QR, so it encodes the LNURL QR too and passes both to the page. The LNURL QR is rendered **hidden**, and a "Lightning QR" button (shown only when a session is active) toggles between the two QRs **client-side** — no extra request. The QR encodes the **uppercase** bech32 (denser QR alphanumeric mode; decodes to the same LNURL as the text). No new endpoint or handler.

(An earlier cut of this PR used a `POST /receive/lnurl-qr` endpoint + handler + a separate view, mirroring the "Receive via BTC" button. But that round-trip is only justified for "Receive via BTC" because it *creates* a chain swap; the LNURL already exists, so the endpoint was dropped in favour of the inline toggle — net −60 lines.)

## Testing

- **web-e2e** (`07-receive-lnurl-qr.spec.ts`): the LNURL QR is hidden until the "Lightning QR" button is clicked, then visible (and the BIP21 QR hidden). Passes locally alongside `01-init`.
