### PR TITLE
fix(core): gate readiness so a post-unlock request can't nil-deref

### DIFF
--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -116,7 +116,10 @@ type Service struct {
 	// Notification channels
 	notifications chan Notification
 
-	stopVtxoEventListener chan struct{}
+	// vtxoListenerCancel stops subscribeForVtxoEvent. A context cancel is idempotent
+	// and non-blocking, so lock and unlock-rollback can stop the listener without the
+	// unbuffered-channel hand-off that could hang if it had already exited.
+	vtxoListenerCancel context.CancelFunc
 
 	// renewing is a single-flight guard so that, while we are settling to renew
 	// already-expired vtxos, concurrent vtxo events don't pile up extra settles.
@@ -208,20 +211,19 @@ func newService(
 		}
 
 		svc := &Service{
-			BuildInfo:             buildInfo,
-			ArkClient:             arkClient,
-			dbSvc:                 dbSvc,
-			schedulerSvc:          schedulerSvc,
-			publicKey:             nil,
-			isInitialized:         true,
-			notifications:         make(chan Notification),
-			stopVtxoEventListener: make(chan struct{}),
-			esploraUrl:            data.ExplorerURL,
-			boltzUrl:              boltzUrl,
-			boltzWSUrl:            boltzWSUrl,
-			swapTimeout:           swapTimeout,
-			walletUpdates:         make(chan WalletUpdate),
-			syncLock:              &sync.RWMutex{},
+			BuildInfo:     buildInfo,
+			ArkClient:     arkClient,
+			dbSvc:         dbSvc,
+			schedulerSvc:  schedulerSvc,
+			publicKey:     nil,
+			isInitialized: true,
+			notifications: make(chan Notification),
+			esploraUrl:    data.ExplorerURL,
+			boltzUrl:      boltzUrl,
+			boltzWSUrl:    boltzWSUrl,
+			swapTimeout:   swapTimeout,
+			walletUpdates: make(chan WalletUpdate),
+			syncLock:      &sync.RWMutex{},
 		}
 
 		if err := svc.RefreshServerConfig(context.Background()); err != nil {
@@ -249,18 +251,17 @@ func newService(
 	}
 
 	svc := &Service{
-		BuildInfo:             buildInfo,
-		ArkClient:             arkClient,
-		dbSvc:                 dbSvc,
-		schedulerSvc:          schedulerSvc,
-		notifications:         make(chan Notification),
-		stopVtxoEventListener: make(chan struct{}),
-		esploraUrl:            esploraUrl,
-		boltzUrl:              boltzUrl,
-		boltzWSUrl:            boltzWSUrl,
-		swapTimeout:           swapTimeout,
-		walletUpdates:         make(chan WalletUpdate),
-		syncLock:              &sync.RWMutex{},
+		BuildInfo:     buildInfo,
+		ArkClient:     arkClient,
+		dbSvc:         dbSvc,
+		schedulerSvc:  schedulerSvc,
+		notifications: make(chan Notification),
+		esploraUrl:    esploraUrl,
+		boltzUrl:      boltzUrl,
+		boltzWSUrl:    boltzWSUrl,
+		swapTimeout:   swapTimeout,
+		walletUpdates: make(chan WalletUpdate),
+		syncLock:      &sync.RWMutex{},
 	}
 
 	return svc, nil
@@ -432,10 +433,11 @@ func (s *Service) LockNode(ctx context.Context) error {
 		s.externalSubscription.stop()
 	}
 
-	// close boarding event listener
-	s.stopVtxoEventListener <- struct{}{}
-	close(s.stopVtxoEventListener)
-	s.stopVtxoEventListener = make(chan struct{})
+	// stop the vtxo event listener (cancel is idempotent and never blocks)
+	if s.vtxoListenerCancel != nil {
+		s.vtxoListenerCancel()
+		s.vtxoListenerCancel = nil
+	}
 
 	s.walletReady.Store(false)
 	s.syncEvent = nil
@@ -449,6 +451,40 @@ func (s *Service) LockNode(ctx context.Context) error {
 	}()
 
 	return nil
+}
+
+// unwindFailedUnlock rolls back a partially-completed unlock so the wallet
+// returns to a clean locked state and a fresh unlock can retry, instead of being
+// stuck "finalizing unlock" until a restart. It runs only from UnlockNode's
+// post-sync goroutine after wg.Wait, and LockNode is gated out while walletReady
+// is false, so there is no concurrent teardown to race with.
+func (s *Service) unwindFailedUnlock() {
+	if s.schedulerSvc != nil {
+		s.schedulerSvc.Stop()
+	}
+	if s.externalSubscription != nil {
+		s.externalSubscription.stop()
+	}
+	// stop the vtxo event listener if it launched (cancel is idempotent / non-blocking)
+	if s.vtxoListenerCancel != nil {
+		s.vtxoListenerCancel()
+		s.vtxoListenerCancel = nil
+	}
+
+	s.walletReady.Store(false)
+	s.syncEvent = nil
+	if s.syncCh != nil {
+		close(s.syncCh)
+		s.syncCh = nil
+	}
+
+	// Re-lock LAST. s.Lock makes IsLocked() return true, which reopens UnlockNode's
+	// guard; tearing down syncCh/syncEvent/walletReady first means a retry that races
+	// in right after the lock allocates a fresh syncCh instead of finding this one
+	// mid-close (a send on a closed syncCh would panic its sync goroutine).
+	if err := s.Lock(context.Background()); err != nil {
+		log.WithError(err).Error("failed to re-lock after a failed unlock")
+	}
 }
 
 func (s *Service) UnlockNode(ctx context.Context, password string) error {
@@ -511,12 +547,14 @@ func (s *Service) UnlockNode(ctx context.Context, password string) error {
 		prvkeyStr, err := s.Dump(ctx)
 		if err != nil {
 			log.WithError(err).Error("failed to get delegate signer key")
+			s.unwindFailedUnlock()
 			return
 		}
 
 		buf, err := hex.DecodeString(prvkeyStr)
 		if err != nil {
 			log.WithError(err).Error("failed to decode delegate signer key")
+			s.unwindFailedUnlock()
 			return
 		}
 
@@ -544,12 +582,14 @@ func (s *Service) UnlockNode(ctx context.Context, password string) error {
 		go s.resumePendingSwapRefunds(ctx)
 
 		// Detach from the request-scoped ctx: this listener lives for the whole
-		// unlocked session (stopped via stopVtxoEventListener), and it makes
+		// unlocked session (stopped by cancelling its context), and it makes
 		// long-lived sdk calls (ListVtxos/Settle) on every refresh. If it kept
 		// the UnlockNode ctx, that ctx being canceled after unlock returns would
 		// make every refresh fail with "context canceled" and silently stop
 		// rescheduling settlements.
-		go s.subscribeForVtxoEvent(context.Background(), arkConfig)
+		listenerCtx, cancel := context.WithCancel(context.Background())
+		s.vtxoListenerCancel = cancel
+		go s.subscribeForVtxoEvent(listenerCtx, arkConfig)
 
 		// Schedule next settlement for the current vtxo set. Subsequent updates
 		// are handled by subscribeForVtxoEvent and its periodic safety check.
@@ -561,7 +601,8 @@ func (s *Service) UnlockNode(ctx context.Context, password string) error {
 			s.ArkClient, s.boltzSvc, s.esploraUrl, s.privateKey, s.swapTimeout,
 		)
 		if err != nil {
-			log.WithError(err).Error("failed to create swap handler; leaving wallet not ready")
+			log.WithError(err).Error("failed to create swap handler; rolling back unlock")
+			s.unwindFailedUnlock()
 			return
 		}
 		s.swapHandler = swapHandler
@@ -1991,7 +2032,7 @@ func (s *Service) subscribeForVtxoEvent(ctx context.Context, cfg *clientTypes.Co
 
 	for {
 		select {
-		case <-s.stopVtxoEventListener:
+		case <-ctx.Done():
 			return
 		case <-ticker.C:
 			refresh()

--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -507,17 +507,6 @@ func (s *Service) UnlockNode(ctx context.Context, password string) error {
 	// wallet, so the unlock window can't expose a nil publicKey/privateKey/swapHandler.
 	s.walletReady.Store(false)
 
-	s.syncCh = make(chan types.SyncEvent, 1)
-
-	wg := &sync.WaitGroup{}
-	wg.Go(func() {
-		s.syncLock.Lock()
-		defer s.syncLock.Unlock()
-		ev := <-s.ArkClient.IsSynced(context.Background())
-		s.syncEvent = &ev
-		s.syncCh <- ev
-	})
-
 	if err := s.Unlock(ctx, password); err != nil {
 		return err
 	}
@@ -537,6 +526,21 @@ func (s *Service) UnlockNode(ctx context.Context, password string) error {
 		return err
 	}
 	s.externalSubscription = subsHandler
+
+	// Arm the sync waiter only now that every synchronous failure path is past.
+	// Arming it before Unlock/GetConfigData/newSubscriptionHandler can still fail
+	// would leave this goroutine blocked on IsSynced while holding syncLock (a
+	// failed unlock never syncs), wedging every later retry. Starting it here can't
+	// miss the event: IsSynced replays a completed sync via its syncDone fast-path.
+	s.syncCh = make(chan types.SyncEvent, 1)
+	wg := &sync.WaitGroup{}
+	wg.Go(func() {
+		s.syncLock.Lock()
+		defer s.syncLock.Unlock()
+		ev := <-s.ArkClient.IsSynced(context.Background())
+		s.syncEvent = &ev
+		s.syncCh <- ev
+	})
 
 	// This go routine takes care of scheduling the next settlement and restore the watch
 	// for the subscribed addresses.

--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -104,6 +104,7 @@ type Service struct {
 	swapTimeout uint32
 
 	isInitialized bool
+	walletReady   atomic.Bool // true once UnlockNode has populated publicKey/privateKey/swapHandler
 	syncLock      *sync.RWMutex
 	syncEvent     *types.SyncEvent
 	syncCh        chan types.SyncEvent
@@ -436,6 +437,7 @@ func (s *Service) LockNode(ctx context.Context) error {
 	close(s.stopVtxoEventListener)
 	s.stopVtxoEventListener = make(chan struct{})
 
+	s.walletReady.Store(false)
 	s.syncEvent = nil
 	if s.syncCh != nil {
 		close(s.syncCh)
@@ -456,6 +458,10 @@ func (s *Service) UnlockNode(ctx context.Context, password string) error {
 	if !s.ArkClient.IsLocked(ctx) {
 		return nil
 	}
+
+	// Stays closed until the post-sync goroutine below finishes assembling the
+	// wallet, so the unlock window can't expose a nil publicKey/privateKey/swapHandler.
+	s.walletReady.Store(false)
 
 	s.syncCh = make(chan types.SyncEvent, 1)
 
@@ -556,6 +562,10 @@ func (s *Service) UnlockNode(ctx context.Context, password string) error {
 			s.ArkClient, s.boltzSvc, s.esploraUrl, s.privateKey, s.swapTimeout,
 		)
 
+		// All gate-required fields are populated; open the gate. The atomic store
+		// publishes the writes above to any reader that passes the gate.
+		s.walletReady.Store(true)
+
 		go s.recoverChainSwaps(context.Background(), arkConfig)
 
 		s.sanitize(context.Background())
@@ -595,6 +605,7 @@ func (s *Service) ResetWallet(ctx context.Context) error {
 	}
 
 	s.isInitialized = false
+	s.walletReady.Store(false)
 	s.syncEvent = nil
 	if s.syncCh != nil {
 		close(s.syncCh)
@@ -1597,6 +1608,13 @@ func (s *Service) isInitializedAndUnlocked(ctx context.Context) error {
 
 	if s.syncEvent == nil {
 		return fmt.Errorf("service is syncing")
+	}
+
+	// syncEvent only signals that the sdk finished syncing; UnlockNode's post-sync
+	// goroutine then populates publicKey/privateKey/swapHandler. Gate on walletReady
+	// too so a request in that window fails cleanly instead of nil-derefing a field.
+	if !s.walletReady.Load() {
+		return fmt.Errorf("wallet is finalizing unlock")
 	}
 
 	return nil

--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -557,10 +557,14 @@ func (s *Service) UnlockNode(ctx context.Context, password string) error {
 			log.WithError(err).Error("failed to schedule next settlement")
 		}
 
-		// nolint
-		s.swapHandler, _ = swap.NewSwapHandler(
+		swapHandler, err := swap.NewSwapHandler(
 			s.ArkClient, s.boltzSvc, s.esploraUrl, s.privateKey, s.swapTimeout,
 		)
+		if err != nil {
+			log.WithError(err).Error("failed to create swap handler; leaving wallet not ready")
+			return
+		}
+		s.swapHandler = swapHandler
 
 		// All gate-required fields are populated; open the gate. The atomic store
 		// publishes the writes above to any reader that passes the gate.

--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -543,6 +543,13 @@ func (s *Service) UnlockNode(ctx context.Context, password string) error {
 	// All operations that require the sdk client to be synced must stay here.
 	// TODO: Improve by handling the errors instead of just logging them.
 	go func() {
+		// This goroutine outlives UnlockNode, so its request-scoped ctx is likely
+		// already canceled by the time wg.Wait returns. Use a detached context for
+		// the finalization work below (same reason the vtxo listener detaches): a
+		// canceled ctx would make Dump/resumePendingSwapRefunds fail and spuriously
+		// trigger unwindFailedUnlock on an unlock the caller already saw succeed.
+		finalizeCtx := context.Background()
+
 		// We must wait for the client to be synced before doing anything.
 		wg.Wait()
 
@@ -552,7 +559,7 @@ func (s *Service) UnlockNode(ctx context.Context, password string) error {
 		}
 
 		// Load delegate signer key.
-		prvkeyStr, err := s.Dump(ctx)
+		prvkeyStr, err := s.Dump(finalizeCtx)
 		if err != nil {
 			log.WithError(err).Error("failed to get delegate signer key")
 			s.unwindFailedUnlock()
@@ -587,7 +594,7 @@ func (s *Service) UnlockNode(ctx context.Context, password string) error {
 		}
 
 		// Resume pending swap refunds.
-		go s.resumePendingSwapRefunds(ctx)
+		go s.resumePendingSwapRefunds(finalizeCtx)
 
 		// Detach from the request-scoped ctx: this listener lives for the whole
 		// unlocked session (stopped by cancelling its context), and it makes

--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -471,6 +471,14 @@ func (s *Service) unwindFailedUnlock() {
 		s.vtxoListenerCancel = nil
 	}
 
+	// Stop the delegate service that onUnlock may have started before the failure;
+	// otherwise its event loops keep running against the wallet we re-lock below.
+	// Stop is idempotent and non-blocking, so this is safe even on the early paths
+	// where onUnlock never ran.
+	if s.onLock != nil {
+		s.onLock()
+	}
+
 	s.walletReady.Store(false)
 	s.syncEvent = nil
 	if s.syncCh != nil {

--- a/internal/core/application/settlement_schedule_test.go
+++ b/internal/core/application/settlement_schedule_test.go
@@ -173,6 +173,8 @@ func newTestService(t *testing.T, fake *fakeArkClient) (*Service, func(types.Vtx
 		isInitialized: true,
 		syncEvent:     &types.SyncEvent{},
 	}
+	// The gate also requires the wallet to be fully assembled (publicKey/swapHandler).
+	svc.walletReady.Store(true)
 
 	// SessionDuration is tiny so the 2-session safety offset doesn't push
 	// far-future schedules around in a way that would confuse the assertions.

--- a/internal/core/application/settlement_schedule_test.go
+++ b/internal/core/application/settlement_schedule_test.go
@@ -102,6 +102,10 @@ type fakeArkClient struct {
 	// onSettle, if set, is run while holding the lock when Settle is called,
 	// so a test can simulate the vtxo set being renewed by the settlement.
 	onSettle func()
+
+	// locked / unlockErr let a test drive UnlockNode's guard and its Unlock call.
+	locked    bool
+	unlockErr error
 }
 
 func newFakeArkClient() *fakeArkClient {
@@ -136,7 +140,15 @@ func (f *fakeArkClient) GetVtxoEventChannel(_ context.Context) <-chan types.Vtxo
 	return f.eventCh
 }
 
-func (f *fakeArkClient) IsLocked(_ context.Context) bool { return false }
+func (f *fakeArkClient) IsLocked(_ context.Context) bool { return f.locked }
+
+func (f *fakeArkClient) Unlock(_ context.Context, _ string) error { return f.unlockErr }
+
+// IsSynced returns a channel that never fires, mimicking the SDK when a wallet
+// was never unlocked (e.g. a failed Unlock): the sync never completes.
+func (f *fakeArkClient) IsSynced(_ context.Context) <-chan types.SyncEvent {
+	return make(chan types.SyncEvent)
+}
 
 func (f *fakeArkClient) Lock(_ context.Context) error {
 	f.mu.Lock()

--- a/internal/core/application/settlement_schedule_test.go
+++ b/internal/core/application/settlement_schedule_test.go
@@ -94,10 +94,11 @@ func TestSettlementScheduleSettlesAlreadyExpiredVtxos(t *testing.T) {
 type fakeArkClient struct {
 	arksdk.ArkClient
 
-	mu        sync.Mutex
-	spendable []clientTypes.Vtxo
-	eventCh   chan types.VtxoEvent
-	settles   int
+	mu         sync.Mutex
+	spendable  []clientTypes.Vtxo
+	eventCh    chan types.VtxoEvent
+	settles    int
+	lockCalled bool
 	// onSettle, if set, is run while holding the lock when Settle is called,
 	// so a test can simulate the vtxo set being renewed by the settlement.
 	onSettle func()
@@ -137,6 +138,19 @@ func (f *fakeArkClient) GetVtxoEventChannel(_ context.Context) <-chan types.Vtxo
 
 func (f *fakeArkClient) IsLocked(_ context.Context) bool { return false }
 
+func (f *fakeArkClient) Lock(_ context.Context) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.lockCalled = true
+	return nil
+}
+
+func (f *fakeArkClient) wasLocked() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.lockCalled
+}
+
 func (f *fakeArkClient) Settle(_ context.Context, _ ...arksdk.BatchSessionOption) (string, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -165,9 +179,8 @@ func newTestService(t *testing.T, fake *fakeArkClient) (*Service, func(types.Vtx
 	sched.Start()
 
 	svc := &Service{
-		ArkClient:             fake,
-		schedulerSvc:          sched,
-		stopVtxoEventListener: make(chan struct{}),
+		ArkClient:    fake,
+		schedulerSvc: sched,
 		// Mark the service initialized/unlocked/synced so the guarded Settle
 		// (isInitializedAndUnlocked) used by the renewal path is allowed to run.
 		isInitialized: true,
@@ -180,10 +193,12 @@ func newTestService(t *testing.T, fake *fakeArkClient) (*Service, func(types.Vtx
 	// far-future schedules around in a way that would confuse the assertions.
 	cfg := &clientTypes.Config{SessionDuration: 1}
 
-	go svc.subscribeForVtxoEvent(context.Background(), cfg)
+	listenerCtx, cancel := context.WithCancel(context.Background())
+	svc.vtxoListenerCancel = cancel
+	go svc.subscribeForVtxoEvent(listenerCtx, cfg)
 
 	t.Cleanup(func() {
-		close(svc.stopVtxoEventListener)
+		cancel()
 		sched.Stop()
 	})
 

--- a/internal/core/application/unlock_readiness_test.go
+++ b/internal/core/application/unlock_readiness_test.go
@@ -1,0 +1,31 @@
+package application
+
+import (
+	"context"
+	"testing"
+
+	"github.com/arkade-os/go-sdk/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUnlockWindowGateBlocksUntilReady is the regression test for the post-unlock
+// nil-deref panic: isInitializedAndUnlocked opened as soon as syncEvent was set,
+// but UnlockNode populates publicKey/privateKey/swapHandler later, in its post-sync
+// goroutine. A request landing in that window dereferenced a nil field and panicked
+// the daemon. The walletReady gate must reject such a request cleanly instead.
+func TestUnlockWindowGateBlocksUntilReady(t *testing.T) {
+	svc := &Service{
+		ArkClient:     newFakeArkClient(), // IsLocked() == false
+		isInitialized: true,
+		syncEvent:     &types.SyncEvent{}, // sync finished, so the old gate would open...
+		// ...but walletReady is still false: the post-sync goroutine hasn't set
+		// publicKey/privateKey/swapHandler yet. This is the crash window.
+	}
+
+	require.ErrorContains(t, svc.isInitializedAndUnlocked(context.Background()), "finalizing",
+		"a request in the unlock window must be rejected, not allowed through to a nil field")
+
+	// Once the post-sync goroutine finishes assembling the wallet, the gate opens.
+	svc.walletReady.Store(true)
+	require.NoError(t, svc.isInitializedAndUnlocked(context.Background()))
+}

--- a/internal/core/application/unlock_recovery_test.go
+++ b/internal/core/application/unlock_recovery_test.go
@@ -2,6 +2,8 @@ package application
 
 import (
 	"context"
+	"errors"
+	"sync"
 	"testing"
 
 	"github.com/arkade-os/go-sdk/types"
@@ -59,4 +61,26 @@ func TestUnwindFailedUnlockStopsDelegate(t *testing.T) {
 
 	require.Nil(t, delegateSvc.cancelFunc, "rollback must stop the delegate service")
 	require.Error(t, delegateCtx.Err(), "rollback must cancel the delegate context so its loops exit")
+}
+
+// TestUnlockNodeFailedUnlockArmsNoSyncState guards against arming the sync waiter
+// before UnlockNode's synchronous failure paths. If Unlock fails, the wallet was
+// never unlocked and the SDK's sync never completes, so a waiter armed before that
+// point blocks forever holding syncLock — wedging every later retry's waiter and
+// leaving the wallet stuck not-ready. A failed unlock must therefore leave syncCh
+// unarmed (the waiter is only started once the synchronous setup has succeeded).
+func TestUnlockNodeFailedUnlockArmsNoSyncState(t *testing.T) {
+	fake := newFakeArkClient()
+	fake.locked = true                            // pass UnlockNode's IsLocked guard
+	fake.unlockErr = errors.New("wrong password") // fail synchronously inside Unlock
+
+	svc := &Service{
+		ArkClient:     fake,
+		isInitialized: true,
+		syncLock:      &sync.RWMutex{},
+	}
+
+	err := svc.UnlockNode(context.Background(), "wrong")
+	require.Error(t, err, "a wrong password must surface the Unlock error")
+	require.Nil(t, svc.syncCh, "a failed unlock must not arm the sync waiter")
 }

--- a/internal/core/application/unlock_recovery_test.go
+++ b/internal/core/application/unlock_recovery_test.go
@@ -1,0 +1,30 @@
+package application
+
+import (
+	"testing"
+
+	"github.com/arkade-os/go-sdk/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUnwindFailedUnlockReLocks is the regression test for in-session recovery:
+// when UnlockNode's post-sync setup fails, unwindFailedUnlock must roll the
+// wallet back to a locked state (so a fresh unlock can retry) rather than leave
+// it stuck not-ready until a restart.
+func TestUnwindFailedUnlockReLocks(t *testing.T) {
+	fake := newFakeArkClient()
+	svc := &Service{
+		ArkClient:     fake,
+		isInitialized: true,
+		syncEvent:     &types.SyncEvent{},
+	}
+	svc.walletReady.Store(true) // pretend assembly got partway before the failure
+
+	// No listener was started, so vtxoListenerCancel is nil and the rollback must
+	// simply skip the listener stop (not deref a nil cancel).
+	svc.unwindFailedUnlock()
+
+	require.True(t, fake.wasLocked(), "a failed unlock must re-lock so it can be retried")
+	require.False(t, svc.walletReady.Load(), "rollback must clear walletReady")
+	require.Nil(t, svc.syncEvent, "rollback must clear syncEvent")
+}

--- a/internal/core/application/unlock_recovery_test.go
+++ b/internal/core/application/unlock_recovery_test.go
@@ -1,6 +1,7 @@
 package application
 
 import (
+	"context"
 	"testing"
 
 	"github.com/arkade-os/go-sdk/types"
@@ -27,4 +28,35 @@ func TestUnwindFailedUnlockReLocks(t *testing.T) {
 	require.True(t, fake.wasLocked(), "a failed unlock must re-lock so it can be retried")
 	require.False(t, svc.walletReady.Load(), "rollback must clear walletReady")
 	require.Nil(t, svc.syncEvent, "rollback must clear syncEvent")
+}
+
+// TestUnwindFailedUnlockStopsDelegate guards the lifecycle symmetry: UnlockNode's
+// post-sync goroutine starts the delegate service (via onUnlock) before assembling
+// the swap handler, so a later failure that triggers unwindFailedUnlock must also
+// stop it (via onLock) — otherwise the delegate event loops keep running against a
+// wallet that rollback just re-locked.
+func TestUnwindFailedUnlockStopsDelegate(t *testing.T) {
+	fake := newFakeArkClient()
+	svc := &Service{
+		ArkClient:     fake,
+		isInitialized: true,
+		syncEvent:     &types.SyncEvent{},
+	}
+	svc.walletReady.Store(true)
+
+	// Wire the delegate lifecycle the way newServiceWithDelegate does.
+	delegateSvc := newDelegateService(svc, 0)
+	svc.onUnlock = func() { delegateSvc.start() }
+	svc.onLock = func() { delegateSvc.Stop() }
+
+	// Simulate onUnlock already having started the delegate (the state start()
+	// leaves behind) without launching its background goroutines.
+	delegateCtx, cancel := context.WithCancel(context.Background())
+	delegateSvc.ctx = delegateCtx
+	delegateSvc.cancelFunc = cancel
+
+	svc.unwindFailedUnlock()
+
+	require.Nil(t, delegateSvc.cancelFunc, "rollback must stop the delegate service")
+	require.Error(t, delegateCtx.Err(), "rollback must cancel the delegate context so its loops exit")
 }


### PR DESCRIPTION
## The problem

`isInitializedAndUnlocked` — the gate in front of `GetAddress`, `GetInvoice`, the VHTLC/refund paths — opens as soon as `syncEvent` is non-nil, which the `wg` goroutine sets the moment the sdk finishes syncing. But `UnlockNode` populates `publicKey`, `privateKey`, and `swapHandler` *later*, in its post-sync goroutine (after `Dump`, key-decode, and the settlement-schedule call). So there's a window where the gate is open but those fields are still nil.

Since gin serves each request on its own goroutine, a request landing in that window passes the gate and dereferences a nil field — e.g. `GetAddress` does `s.publicKey.SerializeCompressed()`, `GetInvoice` does `s.swapHandler.GetInvoice(...)` — and panics the daemon. The window is widest just before `swapHandler` is built, since the settlement-schedule call sits right before it.

This is pre-existing; it predates the recent LNURL work. I actually ran into the shape from the other side: the lnurl receive path navigates it correctly (it starts the receiver *after* `swapHandler` and nil-checks it in the invoice callback), which is what made the gap in the other readers obvious.

## The fix

Add an atomic `walletReady` flag, set `true` only after `swapHandler` is built **and its `NewSwapHandler` error checked** (and `false` on lock/reset and at the start of unlock), then gate on it right after the existing `syncEvent` check. A request in the window now gets a clean "wallet is finalizing unlock" error instead of a nil dereference.

Using `atomic.Bool` matters beyond the flag itself: the store/load establishes happens-before, so any reader that passes the gate is guaranteed to observe the `publicKey`/`privateKey`/`swapHandler` writes — no data race on the fields, and it stays clean under `-race`. The scope is deliberately small: the root cause is just that the gate keyed on "sync started" rather than "wallet assembled", so no struct-wide mutex is needed. (The remaining unsynchronized reads of `boltzSvc`/`isInitialized` are benign stale-reads, not crashes.)

## Testing

- `TestUnlockWindowGateBlocksUntilReady` (new): with `walletReady` false the gate rejects with "finalizing"; once set, it passes. Fails on the old code (the gate returned nil).
- `newTestService` now sets `walletReady` so the existing settlement tests still exercise the guarded `Settle` path; both pass.
- `TestUnwindFailedUnlockReLocks` / `TestUnwindFailedUnlockStopsDelegate`: a failed post-sync setup re-locks the wallet and stops the delegate service as part of the rollback.
- `TestUnlockNodeFailedUnlockArmsNoSyncState`: a failed `Unlock` leaves the sync waiter unarmed, so no stale waiter wedges `syncLock` on a later retry.
- Build/vet/tests green locally; `-race` runs in CI (`make test`), which is the real check for the concurrency aspect — I can't run `-race` locally (no cgo here).

## In-session recovery (now included)

A post-sync setup failure now rolls the wallet back to a clean locked state via `unwindFailedUnlock`, so unlock can be retried in-session without a daemon restart. The rollback is symmetric with `onUnlock` — it stops the scheduler, external subscription, vtxo listener, and the delegate service (`bf82d60`). Two related hardenings landed alongside it:

- Unlock finalization (`Dump`, `resumePendingSwapRefunds`) runs on a detached context, so a canceled RPC ctx can't spuriously roll back an unlock the caller already saw succeed (`74efa5a`).
- The `IsSynced` waiter is armed only after the synchronous failure paths (`Unlock`/`GetConfigData`/`newSubscriptionHandler`), so a failed unlock (e.g. wrong password) can't leave a waiter blocked on `IsSynced` holding `syncLock` and wedge later retries. Safe to arm later because `IsSynced` replays a completed sync via its `syncDone` fast-path (`9e4787d`).

## Note on merge order

This touches the same `UnlockNode` post-sync goroutine, the `Service` struct, and `LockNode` that #444 (LNURL receive) also touches, so expect a small conflict whichever merges second. Happy to rebase this onto #444 (or vice-versa) in whatever order you prefer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented actions from running during the brief unlock-finalization period, reducing errors when the wallet is not fully ready.
  * Improved recovery after a failed unlock so the app returns to a safe locked state instead of getting stuck.
  * Made background listener shutdown more reliable during lock, reset, and unlock transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
