### PR TITLE
fix(core): roll back a failed unlock so it can be retried without a restart

### DIFF
--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -116,11 +116,10 @@ type Service struct {
 	// Notification channels
 	notifications chan Notification
 
-	stopVtxoEventListener chan struct{}
-	// vtxoListenerRunning reports whether subscribeForVtxoEvent is live, so a
-	// rollback only signals stopVtxoEventListener when there's a receiver (a failed
-	// unlock can leave the wallet partially set up before the listener launches).
-	vtxoListenerRunning atomic.Bool
+	// vtxoListenerCancel stops subscribeForVtxoEvent. A context cancel is idempotent
+	// and non-blocking, so lock and unlock-rollback can stop the listener without the
+	// unbuffered-channel hand-off that could hang if it had already exited.
+	vtxoListenerCancel context.CancelFunc
 
 	// renewing is a single-flight guard so that, while we are settling to renew
 	// already-expired vtxos, concurrent vtxo events don't pile up extra settles.
@@ -212,20 +211,19 @@ func newService(
 		}
 
 		svc := &Service{
-			BuildInfo:             buildInfo,
-			ArkClient:             arkClient,
-			dbSvc:                 dbSvc,
-			schedulerSvc:          schedulerSvc,
-			publicKey:             nil,
-			isInitialized:         true,
-			notifications:         make(chan Notification),
-			stopVtxoEventListener: make(chan struct{}),
-			esploraUrl:            data.ExplorerURL,
-			boltzUrl:              boltzUrl,
-			boltzWSUrl:            boltzWSUrl,
-			swapTimeout:           swapTimeout,
-			walletUpdates:         make(chan WalletUpdate),
-			syncLock:              &sync.RWMutex{},
+			BuildInfo:     buildInfo,
+			ArkClient:     arkClient,
+			dbSvc:         dbSvc,
+			schedulerSvc:  schedulerSvc,
+			publicKey:     nil,
+			isInitialized: true,
+			notifications: make(chan Notification),
+			esploraUrl:    data.ExplorerURL,
+			boltzUrl:      boltzUrl,
+			boltzWSUrl:    boltzWSUrl,
+			swapTimeout:   swapTimeout,
+			walletUpdates: make(chan WalletUpdate),
+			syncLock:      &sync.RWMutex{},
 		}
 
 		if err := svc.RefreshServerConfig(context.Background()); err != nil {
@@ -253,18 +251,17 @@ func newService(
 	}
 
 	svc := &Service{
-		BuildInfo:             buildInfo,
-		ArkClient:             arkClient,
-		dbSvc:                 dbSvc,
-		schedulerSvc:          schedulerSvc,
-		notifications:         make(chan Notification),
-		stopVtxoEventListener: make(chan struct{}),
-		esploraUrl:            esploraUrl,
-		boltzUrl:              boltzUrl,
-		boltzWSUrl:            boltzWSUrl,
-		swapTimeout:           swapTimeout,
-		walletUpdates:         make(chan WalletUpdate),
-		syncLock:              &sync.RWMutex{},
+		BuildInfo:     buildInfo,
+		ArkClient:     arkClient,
+		dbSvc:         dbSvc,
+		schedulerSvc:  schedulerSvc,
+		notifications: make(chan Notification),
+		esploraUrl:    esploraUrl,
+		boltzUrl:      boltzUrl,
+		boltzWSUrl:    boltzWSUrl,
+		swapTimeout:   swapTimeout,
+		walletUpdates: make(chan WalletUpdate),
+		syncLock:      &sync.RWMutex{},
 	}
 
 	return svc, nil
@@ -436,13 +433,11 @@ func (s *Service) LockNode(ctx context.Context) error {
 		s.externalSubscription.stop()
 	}
 
-	// close boarding event listener (signal it only if it's running, matching
-	// unwindFailedUnlock, so we don't block if the listener already exited)
-	if s.vtxoListenerRunning.Load() {
-		s.stopVtxoEventListener <- struct{}{}
+	// stop the vtxo event listener (cancel is idempotent and never blocks)
+	if s.vtxoListenerCancel != nil {
+		s.vtxoListenerCancel()
+		s.vtxoListenerCancel = nil
 	}
-	close(s.stopVtxoEventListener)
-	s.stopVtxoEventListener = make(chan struct{})
 
 	s.walletReady.Store(false)
 	s.syncEvent = nil
@@ -470,13 +465,11 @@ func (s *Service) unwindFailedUnlock() {
 	if s.externalSubscription != nil {
 		s.externalSubscription.stop()
 	}
-	// Only signal the listener if it actually launched; an unconditional send
-	// would block forever when the failure preceded subscribeForVtxoEvent.
-	if s.vtxoListenerRunning.Load() {
-		s.stopVtxoEventListener <- struct{}{}
+	// stop the vtxo event listener if it launched (cancel is idempotent / non-blocking)
+	if s.vtxoListenerCancel != nil {
+		s.vtxoListenerCancel()
+		s.vtxoListenerCancel = nil
 	}
-	close(s.stopVtxoEventListener)
-	s.stopVtxoEventListener = make(chan struct{})
 
 	s.walletReady.Store(false)
 	s.syncEvent = nil
@@ -589,13 +582,14 @@ func (s *Service) UnlockNode(ctx context.Context, password string) error {
 		go s.resumePendingSwapRefunds(ctx)
 
 		// Detach from the request-scoped ctx: this listener lives for the whole
-		// unlocked session (stopped via stopVtxoEventListener), and it makes
+		// unlocked session (stopped by cancelling its context), and it makes
 		// long-lived sdk calls (ListVtxos/Settle) on every refresh. If it kept
 		// the UnlockNode ctx, that ctx being canceled after unlock returns would
 		// make every refresh fail with "context canceled" and silently stop
 		// rescheduling settlements.
-		s.vtxoListenerRunning.Store(true)
-		go s.subscribeForVtxoEvent(context.Background(), arkConfig)
+		listenerCtx, cancel := context.WithCancel(context.Background())
+		s.vtxoListenerCancel = cancel
+		go s.subscribeForVtxoEvent(listenerCtx, arkConfig)
 
 		// Schedule next settlement for the current vtxo set. Subsequent updates
 		// are handled by subscribeForVtxoEvent and its periodic safety check.
@@ -2023,7 +2017,6 @@ const vtxoExpiryCheckInterval = 10 * time.Minute
 // it recomputes the earliest expiry across all spendable vtxos and reschedules
 // the next settlement (settling immediately if anything already expired).
 func (s *Service) subscribeForVtxoEvent(ctx context.Context, cfg *clientTypes.Config) {
-	defer s.vtxoListenerRunning.Store(false)
 	eventsCh := s.GetVtxoEventChannel(ctx)
 
 	ticker := time.NewTicker(vtxoExpiryCheckInterval)
@@ -2039,7 +2032,7 @@ func (s *Service) subscribeForVtxoEvent(ctx context.Context, cfg *clientTypes.Co
 
 	for {
 		select {
-		case <-s.stopVtxoEventListener:
+		case <-ctx.Done():
 			return
 		case <-ticker.C:
 			refresh()

--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -117,6 +117,10 @@ type Service struct {
 	notifications chan Notification
 
 	stopVtxoEventListener chan struct{}
+	// vtxoListenerRunning reports whether subscribeForVtxoEvent is live, so a
+	// rollback only signals stopVtxoEventListener when there's a receiver (a failed
+	// unlock can leave the wallet partially set up before the listener launches).
+	vtxoListenerRunning atomic.Bool
 
 	// renewing is a single-flight guard so that, while we are settling to renew
 	// already-expired vtxos, concurrent vtxo events don't pile up extra settles.
@@ -451,6 +455,37 @@ func (s *Service) LockNode(ctx context.Context) error {
 	return nil
 }
 
+// unwindFailedUnlock rolls back a partially-completed unlock so the wallet
+// returns to a clean locked state and a fresh unlock can retry, instead of being
+// stuck "finalizing unlock" until a restart. It runs only from UnlockNode's
+// post-sync goroutine after wg.Wait, and LockNode is gated out while walletReady
+// is false, so there is no concurrent teardown to race with.
+func (s *Service) unwindFailedUnlock() {
+	if s.schedulerSvc != nil {
+		s.schedulerSvc.Stop()
+	}
+	if s.externalSubscription != nil {
+		s.externalSubscription.stop()
+	}
+	// Only signal the listener if it actually launched; an unconditional send
+	// would block forever when the failure preceded subscribeForVtxoEvent.
+	if s.vtxoListenerRunning.Load() {
+		s.stopVtxoEventListener <- struct{}{}
+	}
+	close(s.stopVtxoEventListener)
+	s.stopVtxoEventListener = make(chan struct{})
+
+	if err := s.Lock(context.Background()); err != nil {
+		log.WithError(err).Error("failed to re-lock after a failed unlock")
+	}
+	s.walletReady.Store(false)
+	s.syncEvent = nil
+	if s.syncCh != nil {
+		close(s.syncCh)
+		s.syncCh = nil
+	}
+}
+
 func (s *Service) UnlockNode(ctx context.Context, password string) error {
 	if !s.isInitialized {
 		return fmt.Errorf("service not initialized")
@@ -511,12 +546,14 @@ func (s *Service) UnlockNode(ctx context.Context, password string) error {
 		prvkeyStr, err := s.Dump(ctx)
 		if err != nil {
 			log.WithError(err).Error("failed to get delegate signer key")
+			s.unwindFailedUnlock()
 			return
 		}
 
 		buf, err := hex.DecodeString(prvkeyStr)
 		if err != nil {
 			log.WithError(err).Error("failed to decode delegate signer key")
+			s.unwindFailedUnlock()
 			return
 		}
 
@@ -549,6 +586,7 @@ func (s *Service) UnlockNode(ctx context.Context, password string) error {
 		// the UnlockNode ctx, that ctx being canceled after unlock returns would
 		// make every refresh fail with "context canceled" and silently stop
 		// rescheduling settlements.
+		s.vtxoListenerRunning.Store(true)
 		go s.subscribeForVtxoEvent(context.Background(), arkConfig)
 
 		// Schedule next settlement for the current vtxo set. Subsequent updates
@@ -561,7 +599,8 @@ func (s *Service) UnlockNode(ctx context.Context, password string) error {
 			s.ArkClient, s.boltzSvc, s.esploraUrl, s.privateKey, s.swapTimeout,
 		)
 		if err != nil {
-			log.WithError(err).Error("failed to create swap handler; leaving wallet not ready")
+			log.WithError(err).Error("failed to create swap handler; rolling back unlock")
+			s.unwindFailedUnlock()
 			return
 		}
 		s.swapHandler = swapHandler
@@ -1976,6 +2015,7 @@ const vtxoExpiryCheckInterval = 10 * time.Minute
 // it recomputes the earliest expiry across all spendable vtxos and reschedules
 // the next settlement (settling immediately if anything already expired).
 func (s *Service) subscribeForVtxoEvent(ctx context.Context, cfg *clientTypes.Config) {
+	defer s.vtxoListenerRunning.Store(false)
 	eventsCh := s.GetVtxoEventChannel(ctx)
 
 	ticker := time.NewTicker(vtxoExpiryCheckInterval)

--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -436,8 +436,11 @@ func (s *Service) LockNode(ctx context.Context) error {
 		s.externalSubscription.stop()
 	}
 
-	// close boarding event listener
-	s.stopVtxoEventListener <- struct{}{}
+	// close boarding event listener (signal it only if it's running, matching
+	// unwindFailedUnlock, so we don't block if the listener already exited)
+	if s.vtxoListenerRunning.Load() {
+		s.stopVtxoEventListener <- struct{}{}
+	}
 	close(s.stopVtxoEventListener)
 	s.stopVtxoEventListener = make(chan struct{})
 
@@ -475,14 +478,19 @@ func (s *Service) unwindFailedUnlock() {
 	close(s.stopVtxoEventListener)
 	s.stopVtxoEventListener = make(chan struct{})
 
-	if err := s.Lock(context.Background()); err != nil {
-		log.WithError(err).Error("failed to re-lock after a failed unlock")
-	}
 	s.walletReady.Store(false)
 	s.syncEvent = nil
 	if s.syncCh != nil {
 		close(s.syncCh)
 		s.syncCh = nil
+	}
+
+	// Re-lock LAST. s.Lock makes IsLocked() return true, which reopens UnlockNode's
+	// guard; tearing down syncCh/syncEvent/walletReady first means a retry that races
+	// in right after the lock allocates a fresh syncCh instead of finding this one
+	// mid-close (a send on a closed syncCh would panic its sync goroutine).
+	if err := s.Lock(context.Background()); err != nil {
+		log.WithError(err).Error("failed to re-lock after a failed unlock")
 	}
 }
 

--- a/internal/core/application/settlement_schedule_test.go
+++ b/internal/core/application/settlement_schedule_test.go
@@ -94,10 +94,11 @@ func TestSettlementScheduleSettlesAlreadyExpiredVtxos(t *testing.T) {
 type fakeArkClient struct {
 	arksdk.ArkClient
 
-	mu        sync.Mutex
-	spendable []clientTypes.Vtxo
-	eventCh   chan types.VtxoEvent
-	settles   int
+	mu         sync.Mutex
+	spendable  []clientTypes.Vtxo
+	eventCh    chan types.VtxoEvent
+	settles    int
+	lockCalled bool
 	// onSettle, if set, is run while holding the lock when Settle is called,
 	// so a test can simulate the vtxo set being renewed by the settlement.
 	onSettle func()
@@ -136,6 +137,19 @@ func (f *fakeArkClient) GetVtxoEventChannel(_ context.Context) <-chan types.Vtxo
 }
 
 func (f *fakeArkClient) IsLocked(_ context.Context) bool { return false }
+
+func (f *fakeArkClient) Lock(_ context.Context) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.lockCalled = true
+	return nil
+}
+
+func (f *fakeArkClient) wasLocked() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.lockCalled
+}
 
 func (f *fakeArkClient) Settle(_ context.Context, _ ...arksdk.BatchSessionOption) (string, error) {
 	f.mu.Lock()

--- a/internal/core/application/settlement_schedule_test.go
+++ b/internal/core/application/settlement_schedule_test.go
@@ -179,9 +179,8 @@ func newTestService(t *testing.T, fake *fakeArkClient) (*Service, func(types.Vtx
 	sched.Start()
 
 	svc := &Service{
-		ArkClient:             fake,
-		schedulerSvc:          sched,
-		stopVtxoEventListener: make(chan struct{}),
+		ArkClient:    fake,
+		schedulerSvc: sched,
 		// Mark the service initialized/unlocked/synced so the guarded Settle
 		// (isInitializedAndUnlocked) used by the renewal path is allowed to run.
 		isInitialized: true,
@@ -194,10 +193,12 @@ func newTestService(t *testing.T, fake *fakeArkClient) (*Service, func(types.Vtx
 	// far-future schedules around in a way that would confuse the assertions.
 	cfg := &clientTypes.Config{SessionDuration: 1}
 
-	go svc.subscribeForVtxoEvent(context.Background(), cfg)
+	listenerCtx, cancel := context.WithCancel(context.Background())
+	svc.vtxoListenerCancel = cancel
+	go svc.subscribeForVtxoEvent(listenerCtx, cfg)
 
 	t.Cleanup(func() {
-		close(svc.stopVtxoEventListener)
+		cancel()
 		sched.Stop()
 	})
 

--- a/internal/core/application/unlock_recovery_test.go
+++ b/internal/core/application/unlock_recovery_test.go
@@ -14,15 +14,14 @@ import (
 func TestUnwindFailedUnlockReLocks(t *testing.T) {
 	fake := newFakeArkClient()
 	svc := &Service{
-		ArkClient:             fake,
-		stopVtxoEventListener: make(chan struct{}),
-		isInitialized:         true,
-		syncEvent:             &types.SyncEvent{},
+		ArkClient:     fake,
+		isInitialized: true,
+		syncEvent:     &types.SyncEvent{},
 	}
 	svc.walletReady.Store(true) // pretend assembly got partway before the failure
 
-	// No listener was started, so the rollback must skip the unbuffered
-	// stopVtxoEventListener send rather than block on it forever.
+	// No listener was started, so vtxoListenerCancel is nil and the rollback must
+	// simply skip the listener stop (not deref a nil cancel).
 	svc.unwindFailedUnlock()
 
 	require.True(t, fake.wasLocked(), "a failed unlock must re-lock so it can be retried")

--- a/internal/core/application/unlock_recovery_test.go
+++ b/internal/core/application/unlock_recovery_test.go
@@ -1,0 +1,31 @@
+package application
+
+import (
+	"testing"
+
+	"github.com/arkade-os/go-sdk/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUnwindFailedUnlockReLocks is the regression test for in-session recovery:
+// when UnlockNode's post-sync setup fails, unwindFailedUnlock must roll the
+// wallet back to a locked state (so a fresh unlock can retry) rather than leave
+// it stuck not-ready until a restart.
+func TestUnwindFailedUnlockReLocks(t *testing.T) {
+	fake := newFakeArkClient()
+	svc := &Service{
+		ArkClient:             fake,
+		stopVtxoEventListener: make(chan struct{}),
+		isInitialized:         true,
+		syncEvent:             &types.SyncEvent{},
+	}
+	svc.walletReady.Store(true) // pretend assembly got partway before the failure
+
+	// No listener was started, so the rollback must skip the unbuffered
+	// stopVtxoEventListener send rather than block on it forever.
+	svc.unwindFailedUnlock()
+
+	require.True(t, fake.wasLocked(), "a failed unlock must re-lock so it can be retried")
+	require.False(t, svc.walletReady.Load(), "rollback must clear walletReady")
+	require.Nil(t, svc.syncEvent, "rollback must clear syncEvent")
+}


### PR DESCRIPTION
## What

The follow-up CodeRabbit flagged on #448: make a failed unlock recoverable in-session instead of stuck until a restart.

> Stacked on #448. Base it on `fix/unlock-readiness-gate`; GitHub retargets to `master` once #448 merges.

## The problem

#448 made a request landing mid-unlock fail cleanly (`walletReady`) instead of nil-derefing. But if the post-sync setup itself *fails* — `Dump`, key-decode, or `NewSwapHandler` returns an error — `walletReady` stays false forever. Gated calls then return "finalizing" indefinitely, and because `LockNode` is itself gated, the user can't even lock→unlock to retry. Only a restart recovers.

## The fix

`unwindFailedUnlock` rolls the partial setup back on each failure path: it stops the scheduler and the subscription, stops the vtxo listener *if it launched*, then re-locks the wallet. After that the wallet is cleanly locked, so a fresh unlock retries from scratch.

- A `vtxoListenerRunning atomic.Bool` lets the rollback skip the unbuffered `stopVtxoEventListener` send when the failure happened before the listener started — otherwise that send would block forever with no receiver.
- `LockNode` is deliberately left untouched (still gated on `walletReady`). Because it can't run while the wallet isn't ready, there's no concurrent teardown to race the rollback, and the rollback runs after `wg.Wait`, so closing `syncCh` can't race the sync goroutine's send.

### Why this shape (auto-rollback) rather than un-gating LockNode

The obvious "let the user lock→unlock to recover" approach means un-gating `LockNode` so it runs while not-ready — but that lets it run *during the sync wait*, where it `close()`s `syncCh` while the `wg` goroutine is still about to send to it: a send-on-closed-channel **panic**. Auto-rollback avoids that entirely by keeping `LockNode` gated and doing the teardown inside the post-sync goroutine.

## Trade-off

Recovery is asynchronous: the failing setup runs after `UnlockNode` already returned success, so on failure the wallet visibly returns to locked rather than surfacing a synchronous error. That's the honest signal ("unlock didn't complete, try again") and strictly better than the previous stuck state, but worth calling out.

## Testing

- `TestUnwindFailedUnlockReLocks`: the rollback re-locks, clears `walletReady`/`syncEvent`, and does **not** block on the listener stop-send when no listener ran.
- The existing settlement + #448 gate tests still pass.
- Build/vet/tests green locally. **`-race`/integration runs in CI once this retargets to master after #448 merges** — I can't run `-race` on a stack locally (no cgo here), and that's the check that matters most for an unlock-teardown change, so please weight the merge-time CI accordingly.
