### PR TITLE
fix(send): recover SendOffChain from stranded already-spent vtxos

### DIFF
--- a/internal/interface/grpc/handlers/send_recovery.go
+++ b/internal/interface/grpc/handlers/send_recovery.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -42,6 +43,9 @@ func sendOffChainWithRecovery(
 	attempts int,
 	retryDelay time.Duration,
 ) (string, error) {
+	if attempts <= 0 {
+		return "", fmt.Errorf("attempts must be positive, got %d", attempts)
+	}
 	var txid string
 	var err error
 	for attempt := 0; attempt < attempts; attempt++ {

--- a/internal/interface/grpc/handlers/send_recovery.go
+++ b/internal/interface/grpc/handlers/send_recovery.go
@@ -1,0 +1,80 @@
+package handlers
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	clientTypes "github.com/arkade-os/arkd/pkg/client-lib/types"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	// maxSendOffChainAttempts bounds how many times an offchain send is retried
+	// when the server rejects the selected input as already spent.
+	maxSendOffChainAttempts = 3
+	// sendRecoveryRetryDelay gives the SDK's transaction-stream listener a moment
+	// to reconcile the local vtxo db after a stranded pending tx is finalized,
+	// before coins are re-selected and the send retried.
+	sendRecoveryRetryDelay = 1 * time.Second
+)
+
+type sendOffChainFunc func(context.Context, []clientTypes.Receiver) (string, error)
+
+type finalizePendingTxsFunc func(context.Context, *time.Time) ([]string, error)
+
+// sendOffChainWithRecovery performs an offchain send and, when the server
+// rejects the selected input with VTXO_ALREADY_SPENT, attempts to self-heal
+// instead of blindly retrying the same doomed coin selection.
+//
+// An offchain send whose finalization is interrupted after the server has
+// already registered the spend (e.g. a 502 between SubmitTx and FinalizeTx)
+// leaves the input spent server-side yet still spendable in the local db. Coin
+// selection then keeps re-picking that stranded input and every send fails with
+// VTXO_ALREADY_SPENT. Finalizing the pending tx resolves the strand server-side;
+// the SDK's tx-stream listener (and, as a backstop, the periodic db refresh)
+// then drops the input locally so the retry selects valid coins.
+func sendOffChainWithRecovery(
+	ctx context.Context,
+	receivers []clientTypes.Receiver,
+	send sendOffChainFunc,
+	finalizePending finalizePendingTxsFunc,
+	attempts int,
+	retryDelay time.Duration,
+) (string, error) {
+	var txid string
+	var err error
+	for attempt := 0; attempt < attempts; attempt++ {
+		txid, err = send(ctx, receivers)
+		if err == nil {
+			return txid, nil
+		}
+		if !isVtxoAlreadySpent(err) {
+			return "", err
+		}
+
+		// Best-effort: finalize any stranded pending txs so the local db can
+		// reconcile the already-spent input. This is what actually breaks the
+		// loop; the original send error is kept if recovery is not possible.
+		if _, ferr := finalizePending(ctx, nil); ferr != nil {
+			log.WithError(ferr).
+				Warn("failed to finalize pending txs while recovering from already-spent vtxo")
+		}
+
+		if attempt < attempts-1 {
+			select {
+			case <-ctx.Done():
+				return "", ctx.Err()
+			case <-time.After(retryDelay):
+			}
+		}
+	}
+	return "", err
+}
+
+func isVtxoAlreadySpent(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "vtxo_already_spent")
+}

--- a/internal/interface/grpc/handlers/send_recovery_test.go
+++ b/internal/interface/grpc/handlers/send_recovery_test.go
@@ -1,0 +1,108 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	clientTypes "github.com/arkade-os/arkd/pkg/client-lib/types"
+	"github.com/stretchr/testify/require"
+)
+
+// mirrors the server rejection seen when the selected input was already spent by
+// a previously-submitted (but unfinalized) ark tx.
+var errAlreadySpent = errors.New(
+	"rpc error: code = InvalidArgument desc = VTXO_ALREADY_SPENT (6): " +
+		"1d99140b685d1c1d8cadfdf4f7e3a660ed1c72bd24df565df5d7fab7b0eddf6a:0 already spent",
+)
+
+func TestSendOffChainWithRecovery(t *testing.T) {
+	receivers := []clientTypes.Receiver{{To: "ark1test", Amount: 1000}}
+
+	t.Run("finalizes pending txs on already-spent then retries to success", func(t *testing.T) {
+		var sendCalls, finalizeCalls int
+		send := func(context.Context, []clientTypes.Receiver) (string, error) {
+			sendCalls++
+			// The stranded input is only cleared once the pending tx is
+			// finalized and the local db reconciles; model that by succeeding
+			// only after a finalize has happened.
+			if finalizeCalls == 0 {
+				return "", errAlreadySpent
+			}
+			return "goodtxid", nil
+		}
+		finalize := func(context.Context, *time.Time) ([]string, error) {
+			finalizeCalls++
+			return []string{"finalizedtxid"}, nil
+		}
+
+		txid, err := sendOffChainWithRecovery(context.Background(), receivers, send, finalize, 3, 0)
+		require.NoError(t, err)
+		require.Equal(t, "goodtxid", txid)
+		require.Equal(t, 1, finalizeCalls, "should finalize stranded pending txs to recover")
+		require.Equal(t, 2, sendCalls, "should retry the send after finalizing")
+	})
+
+	t.Run("returns unrelated errors immediately without finalizing", func(t *testing.T) {
+		var finalizeCalls int
+		send := func(context.Context, []clientTypes.Receiver) (string, error) {
+			return "", errors.New("insufficient funds")
+		}
+		finalize := func(context.Context, *time.Time) ([]string, error) {
+			finalizeCalls++
+			return nil, nil
+		}
+
+		_, err := sendOffChainWithRecovery(context.Background(), receivers, send, finalize, 3, 0)
+		require.ErrorContains(t, err, "insufficient funds")
+		require.Equal(t, 0, finalizeCalls, "must not finalize for errors unrelated to spent vtxos")
+	})
+
+	t.Run("gives up after max attempts but still finalizes to self-heal", func(t *testing.T) {
+		var sendCalls, finalizeCalls int
+		send := func(context.Context, []clientTypes.Receiver) (string, error) {
+			sendCalls++
+			return "", errAlreadySpent
+		}
+		finalize := func(context.Context, *time.Time) ([]string, error) {
+			finalizeCalls++
+			return nil, nil
+		}
+
+		_, err := sendOffChainWithRecovery(context.Background(), receivers, send, finalize, 3, 0)
+		require.ErrorContains(t, err, "VTXO_ALREADY_SPENT")
+		require.Equal(t, 3, sendCalls, "should exhaust all attempts")
+		require.Equal(t, 3, finalizeCalls, "each already-spent failure should trigger a finalize attempt")
+	})
+
+	t.Run("first attempt succeeds without finalizing", func(t *testing.T) {
+		var finalizeCalls int
+		send := func(context.Context, []clientTypes.Receiver) (string, error) {
+			return "immediate", nil
+		}
+		finalize := func(context.Context, *time.Time) ([]string, error) {
+			finalizeCalls++
+			return nil, nil
+		}
+
+		txid, err := sendOffChainWithRecovery(context.Background(), receivers, send, finalize, 3, 0)
+		require.NoError(t, err)
+		require.Equal(t, "immediate", txid)
+		require.Equal(t, 0, finalizeCalls)
+	})
+
+	t.Run("aborts the retry wait when the context is cancelled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		send := func(context.Context, []clientTypes.Receiver) (string, error) {
+			return "", errAlreadySpent
+		}
+		finalize := func(context.Context, *time.Time) ([]string, error) {
+			cancel() // simulate the caller giving up during recovery
+			return nil, nil
+		}
+
+		_, err := sendOffChainWithRecovery(ctx, receivers, send, finalize, 3, time.Hour)
+		require.ErrorIs(t, err, context.Canceled)
+	})
+}

--- a/internal/interface/grpc/handlers/service_handler.go
+++ b/internal/interface/grpc/handlers/service_handler.go
@@ -181,17 +181,17 @@ func (h *serviceHandler) SendOffChain(
 	}
 
 	receivers := []clientTypes.Receiver{{To: address, Amount: amount}}
-	var arkTxid string
-	for range 3 {
-		arkTxid, err = h.svc.SendOffChain(ctx, receivers)
-		if err != nil {
-			if strings.Contains(strings.ToLower(err.Error()), "vtxo_already_spent") {
-				continue
-			}
-			return nil, err
-		}
-		break
-	}
+	// A send whose finalization was interrupted after the server registered the
+	// spend leaves the input spent server-side but still spendable locally, so a
+	// plain retry keeps re-selecting it. Recover by finalizing the stranded
+	// pending tx between attempts.
+	arkTxid, err := sendOffChainWithRecovery(
+		ctx, receivers,
+		h.svc.SendOffChain,
+		h.svc.FinalizePendingTxs,
+		maxSendOffChainAttempts,
+		sendRecoveryRetryDelay,
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Problem

Under some conditions every `SendOffChain` starts failing with `VTXO_ALREADY_SPENT`, and the node stays stuck until it is restarted:

```
method=/fulmine.v1.Service/SendOffChain ... error="rpc error: code = InvalidArgument
desc = VTXO_ALREADY_SPENT (6): 1d99140b...:0 already spent"
```

The same input is re-selected for hours across many send attempts.

## Root cause

An offchain send is a two-phase, checkpoint-based flow in `client-lib`: `SubmitTx` (server registers the ark tx and marks the input spent) then `FinalizeTx`. If finalization is interrupted **after** `SubmitTx` — e.g. a `502 Bad Gateway` from a proxy in front of arkd landing between the two — the input is spent server-side by an **unfinalized** ark tx, while the SDK only records the spend locally on full success. The local db therefore keeps the input spendable.

Nothing reconciles this while the process runs:

- coin selection reads only the local db, so it keeps re-picking the stranded input;
- the SDK's recovery routine (`FinalizePendingTxs`, which queries the distinct `GetVtxos(WithPendingOnly())` endpoint and finalizes the stuck tx) runs **only once, at unlock**;
- the periodic `refreshDb` reconciles the normal spent-set but never fetches pending-only vtxos or finalizes anything.

So a long-running, un-restarted node never heals. The pre-existing 3× retry in the `SendOffChain` handler didn't help either — it re-ran the same coin selection with no state reconciliation, re-picking the same input each time.

## Fix

On `VTXO_ALREADY_SPENT`, finalize any pending (unfinalized) ark txs before retrying, instead of blindly re-selecting. Finalizing resolves the strand server-side; the SDK's transaction-stream listener then drops the input from the local db, with the periodic refresh as a backstop — so the node self-heals **without a restart**.

The retry/recovery control flow is extracted into `sendOffChainWithRecovery` with injected `send`/`finalizePending` closures, which keeps it unit-testable without constructing the concrete `*application.Service`.

## Test plan

- [x] `go test ./internal/interface/grpc/handlers/` — new `TestSendOffChainWithRecovery` (5 cases: recovers-then-succeeds, unrelated-errors-pass-through-without-finalizing, exhausts-attempts-but-still-finalizes, happy-path-no-finalize, ctx-cancel-during-wait). Written test-first (watched RED against a no-finalize stub, then GREEN).
- [x] `go build ./...`, `go vet`, gofmt clean.
- [ ] Real-node validation: the in-request retry succeeding depends on the finalized-tx stream event reconciling the local db within the retry window; the 60s periodic refresh is the guaranteed backstop. Best validated against a node that has a genuinely stranded unfinalized spend.

## Operational note

This heals the node going forward; a node **already** stuck can be unblocked immediately by restart + unlock (which triggers the SDK's one-time `FinalizePendingTxs`). Note that finalizing completes the stranded send(s).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved offchain send handling so requests that hit an “already spent” condition now attempt recovery and retry automatically.
  * Added best-effort finalization of pending transactions before retrying, helping resolve stranded sends more reliably.
  * Unrelated send errors now fail immediately, and canceled requests stop promptly during recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->