### PR TITLE
.env.regtest: set arkd and arkd wallet to v0.9.14

### DIFF
--- a/.env.regtest
+++ b/.env.regtest
@@ -5,9 +5,8 @@
 # instead of the published default.
 FULMINE_IMAGE=fulmine:e2e
 
-# Pin the Ark stack to a known-good release for reproducible CI.
-ARKD_IMAGE=ghcr.io/arkade-os/arkd:v0.9.9-rc.1
-ARKD_WALLET_IMAGE=ghcr.io/arkade-os/arkd-wallet:v0.9.9-rc.1
+ARKD_IMAGE=ghcr.io/arkade-os/arkd:v0.9.14
+ARKD_WALLET_IMAGE=ghcr.io/arkade-os/arkd-wallet:v0.9.14
 
 # VTXO expiry tuned to outlast the e2e suite without sweeping mid-run.
 # (Tune against the live suite in CI if sweeps fire early — see the plan, Task 5.)


### PR DESCRIPTION
@altafan @sekulicd please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the regtest environment to use the Ark server and wallet images from version 0.9.14.
  * Updated the regtest setup to a newer revision for improved compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->