### PR TITLE
chore: bump Go to 1.26.5

### DIFF
--- a/.github/workflows/ci.integration.yaml
+++ b/.github/workflows/ci.integration.yaml
@@ -16,7 +16,7 @@ jobs:
           submodules: true
       - uses: actions/setup-go@v6
         with:
-          go-version: ">=1.26.2"
+          go-version: ">=1.26.5"
       - uses: actions/setup-node@v4
         with:
           node-version: "20"

--- a/.github/workflows/ci.unit.yaml
+++ b/.github/workflows/ci.unit.yaml
@@ -18,7 +18,7 @@ jobs:
       
       - uses: actions/setup-go@v6
         with:
-          go-version: '>=1.26.2'
+          go-version: '>=1.26.5'
           cache: true
       
       # Run linting with the original working configuration

--- a/.github/workflows/env-doc-check.yaml
+++ b/.github/workflows/env-doc-check.yaml
@@ -15,7 +15,7 @@ jobs:
             fetch-depth: 1
       - uses: actions/setup-go@v3
         with:
-          go-version: '>=1.24.6'
+          go-version: '>=1.26.5'
           cache: true
       - run: go generate ./internal/config
       - run: git diff --exit-code docs/environment.md

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: 1.26.2
+        go-version: 1.26.5
 
     # Build binaries for all architectures
     - name: Build binaries

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY internal/interface/web .
 RUN rm -rf .parcel-cache && yarn && yarn build
 
 # Build the Go application
-FROM golang:1.26.4 AS go-builder
+FROM golang:1.26.5 AS go-builder
 
 ARG VERSION
 ARG COMMIT

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ⚡️fulmine
 
-[![Go Version](https://img.shields.io/badge/Go-1.26.2-blue.svg)](https://golang.org/doc/go1.26)
+[![Go Version](https://img.shields.io/badge/Go-1.26.5-blue.svg)](https://golang.org/doc/go1.26)
 [![GitHub Release](https://img.shields.io/github/v/release/ArkLabsHQ/fulmine)](https://github.com/ArkLabsHQ/fulmine/releases/latest)
 [![License](https://img.shields.io/github/license/ArkLabsHQ/fulmine)](https://github.com/ArkLabsHQ/fulmine/blob/master/LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/ArkLabsHQ/fulmine)](https://github.com/ArkLabsHQ/fulmine/stargazers)
@@ -522,7 +522,7 @@ The examples above cover the most common operations. For the complete request/re
 
 ## 👨‍💻 Development
 
-To get started with fulmine development you need Go `1.26.2` or higher and Node.js `18.17.1` or higher (the Docker image builds the web assets with Node 22).
+To get started with fulmine development you need Go `1.26.5` or higher and Node.js `18.17.1` or higher (the Docker image builds the web assets with Node 22).
 
 ```bash
 git clone https://github.com/ArkLabsHQ/fulmine.git

--- a/api-spec/go.mod
+++ b/api-spec/go.mod
@@ -1,6 +1,6 @@
 module github.com/ArkLabsHQ/fulmine/api-spec
 
-go 1.26.2
+go 1.26.5
 
 require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0

--- a/arkd.Dockerfile
+++ b/arkd.Dockerfile
@@ -1,5 +1,5 @@
 # First image used to build the sources
-FROM golang:1.26.4 AS builder
+FROM golang:1.26.5 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/arkdwallet.Dockerfile
+++ b/arkdwallet.Dockerfile
@@ -1,5 +1,5 @@
 # First stage: build the ark-wallet-daemon binary
-FROM golang:1.26.4 AS builder
+FROM golang:1.26.5 AS builder
 
 ARG VERSION
 ARG TARGETOS

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ArkLabsHQ/fulmine
 
-go 1.26.4
+go 1.26.5
 
 replace github.com/ArkLabsHQ/fulmine/pkg/boltz => ./pkg/boltz
 

--- a/pkg/boltz/go.mod
+++ b/pkg/boltz/go.mod
@@ -1,6 +1,6 @@
 module github.com/ArkLabsHQ/fulmine/pkg/boltz
 
-go 1.26.2
+go 1.26.5
 
 require (
 	github.com/gorilla/websocket v1.5.3

--- a/pkg/swap/go.mod
+++ b/pkg/swap/go.mod
@@ -1,6 +1,6 @@
 module github.com/ArkLabsHQ/fulmine/pkg/swap
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/nbd-wtf/ln-decodepay v1.13.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the project’s minimum Go version to 1.26.5 across development, build, test, release, and module configurations.
  - Updated the Docker build environment to use Go 1.26.5.

- **Documentation**
  - Updated the README to reflect Go 1.26.5 as the required development version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->