### PR TITLE
refactor(db): batch id lookups in the sqlite repositories

### DIFF
--- a/internal/infrastructure/db/bind_variable_limit_test.go
+++ b/internal/infrastructure/db/bind_variable_limit_test.go
@@ -1,0 +1,276 @@
+package db_test
+
+import (
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ArkLabsHQ/fulmine/internal/core/domain"
+	"github.com/ArkLabsHQ/fulmine/internal/infrastructure/db"
+	"github.com/ArkLabsHQ/fulmine/pkg/boltz"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/stretchr/testify/require"
+)
+
+// sqliteMaxVariableNumber mirrors SQLITE_MAX_VARIABLE_NUMBER as compiled into
+// modernc.org/sqlite. A single prepared statement cannot carry more bind
+// variables than this, so any repository method that expands a caller-supplied
+// slice into one variable per element must chunk below it.
+const sqliteMaxVariableNumber = 32766
+
+func TestBindVariableLimit(t *testing.T) {
+	dbDir := t.TempDir()
+	tests := []struct {
+		name   string
+		config db.ServiceConfig
+	}{
+		{
+			name: "badger",
+			config: db.ServiceConfig{
+				DbType:   "badger",
+				DbConfig: []any{"", nil},
+			},
+		},
+		{
+			name: "sqlite",
+			config: db.ServiceConfig{
+				DbType:   "sqlite",
+				DbConfig: []any{dbDir},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, err := db.NewService(tt.config)
+			require.NoError(t, err)
+			defer svc.Close()
+
+			testVHTLCGetByIdsBoundary(t, svc.VHTLC())
+			testDelegateInputsBoundary(t, svc.Delegate())
+
+			// Chain swaps are sqlite-only; the badger backend leaves the repo nil.
+			if tt.name == "sqlite" {
+				testChainSwapGetByIDsBoundary(t, svc.ChainSwaps(), filepath.Join(dbDir, "fulmine.db"))
+			}
+		})
+	}
+}
+
+func testChainSwapGetByIDsBoundary(
+	t *testing.T, repo domain.ChainSwapRepository, dbPath string,
+) {
+	t.Run("get chain swaps by ids over the bind variable limit", func(t *testing.T) {
+		// ListChainSwapsByIDs orders by created_at DESC. Seed the rows so their
+		// insertion order differs from their created_at order, otherwise a
+		// concatenation of per-chunk results would pass by accident.
+		seeds := []struct {
+			id        string
+			createdAt int64
+		}{
+			{"chainswap-boundary-oldest", 1_000},
+			{"chainswap-boundary-newest", 3_000},
+			{"chainswap-boundary-middle", 2_000},
+		}
+		for _, s := range seeds {
+			require.NoError(t, repo.Add(ctx, domain.ChainSwap{
+				Id:     s.id,
+				From:   boltz.CurrencyBtc,
+				To:     boltz.CurrencyArk,
+				Amount: 1000,
+				Status: domain.ChainSwapPending,
+			}))
+			// created_at defaults to a second-resolution clock, so rows inserted
+			// in one test would otherwise be indistinguishable. Set it directly.
+			setChainSwapCreatedAt(t, dbPath, s.id, s.createdAt)
+		}
+
+		wantIDs := []string{
+			"chainswap-boundary-oldest", "chainswap-boundary-newest", "chainswap-boundary-middle",
+		}
+		wantOrder := []string{
+			"chainswap-boundary-newest", "chainswap-boundary-middle", "chainswap-boundary-oldest",
+		}
+
+		for _, size := range boundarySizes() {
+			t.Run(fmt.Sprintf("size=%d", size), func(t *testing.T) {
+				ids := padIDs(wantIDs, size, "chainswap-absent")
+
+				got, err := repo.GetByIDs(ctx, ids)
+				require.NoError(t, err)
+
+				gotIDs := make([]string, 0, len(got))
+				for _, s := range got {
+					gotIDs = append(gotIDs, s.Id)
+				}
+
+				require.ElementsMatch(t, expectedSubset(wantIDs, ids), gotIDs)
+
+				if len(gotIDs) == len(wantOrder) {
+					require.Equal(t, wantOrder, gotIDs,
+						"created_at DESC must hold across the merged chunks")
+				}
+			})
+		}
+	})
+}
+
+// setChainSwapCreatedAt overwrites the DB-assigned created_at so ordering is
+// deterministic. The repository deliberately has no setter for it.
+func setChainSwapCreatedAt(t *testing.T, dbPath, id string, createdAt int64) {
+	t.Helper()
+
+	conn, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	_, err = conn.ExecContext(
+		ctx, "UPDATE chain_swap SET created_at = ? WHERE id = ?", createdAt, id,
+	)
+	require.NoError(t, err)
+}
+
+// boundarySizes exercises the batch sizes either side of the old failure point.
+// The largest entry is deliberately several multiples of the limit so a
+// single-chunk regression cannot slip through.
+func boundarySizes() []int {
+	return []int{
+		1,
+		sqliteMaxVariableNumber - 1,
+		sqliteMaxVariableNumber,
+		sqliteMaxVariableNumber + 1,
+		sqliteMaxVariableNumber * 3,
+	}
+}
+
+func testVHTLCGetByIdsBoundary(t *testing.T, repo domain.VHTLCRepository) {
+	t.Run("get vHTLCs by ids over the bind variable limit", func(t *testing.T) {
+		// Three real rows, so we can assert the chunked read returns exactly the
+		// rows that exist and nothing else.
+		wantIDs := make([]string, 0, 3)
+		for i := 0; i < 3; i++ {
+			v := makeVHTLC()
+			require.NoError(t, repo.Add(ctx, v))
+			wantIDs = append(wantIDs, v.Id)
+		}
+
+		for _, size := range boundarySizes() {
+			t.Run(fmt.Sprintf("size=%d", size), func(t *testing.T) {
+				ids := padIDs(wantIDs, size, "vhtlc-absent")
+
+				got, err := repo.GetByIds(ctx, ids)
+				require.NoError(t, err)
+
+				gotIDs := make([]string, 0, len(got))
+				for _, v := range got {
+					gotIDs = append(gotIDs, v.Id)
+				}
+
+				// Exact ownership: every requested-and-existing row, each once.
+				require.ElementsMatch(t, expectedSubset(wantIDs, ids), gotIDs)
+				require.Len(t, gotIDs, len(dedupe(gotIDs)), "chunking must not duplicate rows")
+			})
+		}
+	})
+}
+
+func testDelegateInputsBoundary(t *testing.T, repo domain.DelegateRepository) {
+	t.Run("get pending task ids by inputs over the bind variable limit", func(t *testing.T) {
+		// A pending task whose single input sits in the *last* chunk, proving
+		// every chunk is queried rather than just the first.
+		markerInput := outpointAt(999_001)
+		task := makeDelegateTaskWithInputs("boundary_inputs_task", markerInput)
+		require.NoError(t, repo.Add(ctx, task))
+
+		for _, size := range boundarySizes() {
+			t.Run(fmt.Sprintf("size=%d", size), func(t *testing.T) {
+				inputs := make([]wire.OutPoint, 0, size)
+				for i := 0; i < size-1; i++ {
+					inputs = append(inputs, outpointAt(i))
+				}
+				inputs = append(inputs, markerInput)
+
+				got, err := repo.GetPendingTaskIDsByInputs(ctx, inputs)
+				require.NoError(t, err)
+				require.Equal(t, []string{task.ID}, got,
+					"the task must be reported exactly once across all chunks")
+			})
+		}
+	})
+}
+
+// padIDs returns a slice of exactly size entries containing every id in want,
+// padded with ids that do not exist in the store. The real ids are placed at the
+// end so a partial (first-chunk-only) implementation cannot pass by accident.
+func padIDs(want []string, size int, prefix string) []string {
+	if size <= len(want) {
+		return append([]string(nil), want[:size]...)
+	}
+
+	ids := make([]string, 0, size)
+	for i := 0; i < size-len(want); i++ {
+		ids = append(ids, fmt.Sprintf("%s-%d", prefix, i))
+	}
+	return append(ids, want...)
+}
+
+// expectedSubset returns the entries of want that actually appear in requested.
+func expectedSubset(want, requested []string) []string {
+	present := make(map[string]struct{}, len(requested))
+	for _, id := range requested {
+		present[id] = struct{}{}
+	}
+
+	out := make([]string, 0, len(want))
+	for _, id := range want {
+		if _, ok := present[id]; ok {
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
+func dedupe(ids []string) []string {
+	seen := make(map[string]struct{}, len(ids))
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	return out
+}
+
+func outpointAt(i int) wire.OutPoint {
+	hash, _ := chainhash.NewHashFromStr(
+		fmt.Sprintf("%064x", 1),
+	)
+	return wire.OutPoint{Hash: *hash, Index: uint32(i)}
+}
+
+func makeDelegateTaskWithInputs(id string, inputs ...wire.OutPoint) domain.DelegateTask {
+	forfeits := make(map[wire.OutPoint]string, len(inputs))
+	for _, in := range inputs {
+		forfeits[in] = "forfeit_tx_hex"
+	}
+
+	return domain.DelegateTask{
+		ID: id,
+		Intent: domain.Intent{
+			Message: "boundary_message",
+			Proof:   "boundary_proof",
+			Txid:    "txid_" + id,
+			Inputs:  inputs,
+		},
+		ForfeitTxs:        forfeits,
+		Fee:               1000,
+		DelegatePublicKey: "delegate_pubkey",
+		ScheduledAt:       time.Now(),
+		Status:            domain.DelegateTaskStatusPending,
+	}
+}

--- a/internal/infrastructure/db/bind_variable_limit_writes_test.go
+++ b/internal/infrastructure/db/bind_variable_limit_writes_test.go
@@ -1,0 +1,135 @@
+package db_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ArkLabsHQ/fulmine/internal/core/domain"
+	"github.com/ArkLabsHQ/fulmine/internal/infrastructure/db"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBindVariableLimitStatusUpdates covers the delegate task status transitions,
+// which expand an id slice into bind variables the same way the reads do.
+//
+// CancelTasks binds one variable per id. CompleteTasks and FailTasks bind an
+// extra leading variable (commitment txid / fail reason) before the id list, so
+// they overflow one id *earlier* than CancelTasks does — a fix that chunked at
+// exactly the raw limit would still have been broken for those two.
+func TestBindVariableLimitStatusUpdates(t *testing.T) {
+	dbDir := t.TempDir()
+	tests := []struct {
+		name   string
+		config db.ServiceConfig
+	}{
+		{
+			name: "badger",
+			config: db.ServiceConfig{
+				DbType:   "badger",
+				DbConfig: []any{"", nil},
+			},
+		},
+		{
+			name: "sqlite",
+			config: db.ServiceConfig{
+				DbType:   "sqlite",
+				DbConfig: []any{dbDir},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, err := db.NewService(tt.config)
+			require.NoError(t, err)
+			defer svc.Close()
+
+			repo := svc.Delegate()
+
+			updates := []struct {
+				name   string
+				update func(ids []string) error
+				status domain.DelegateTaskStatus
+			}{
+				{
+					name:   "cancel",
+					update: func(ids []string) error { return repo.CancelTasks(ctx, ids...) },
+					status: domain.DelegateTaskStatusCancelled,
+				},
+				{
+					name: "complete",
+					update: func(ids []string) error {
+						return repo.CompleteTasks(ctx, "boundary_commitment_txid", ids...)
+					},
+					status: domain.DelegateTaskStatusCompleted,
+				},
+				{
+					name: "fail",
+					update: func(ids []string) error {
+						return repo.FailTasks(ctx, "boundary failure reason", ids...)
+					},
+					status: domain.DelegateTaskStatusFailed,
+				},
+			}
+
+			for _, u := range updates {
+				t.Run(u.name+" tasks over the bind variable limit", func(t *testing.T) {
+					for _, size := range boundarySizes() {
+						t.Run(fmt.Sprintf("size=%d", size), func(t *testing.T) {
+							// Two real pending tasks: one first, one last. The
+							// update must reach the final chunk to transition the
+							// second, so a first-chunk-only implementation fails.
+							first := fmt.Sprintf("boundary_%s_%d_first", u.name, size)
+							last := fmt.Sprintf("boundary_%s_%d_last", u.name, size)
+							for i, id := range []string{first, last} {
+								require.NoError(t, repo.Add(ctx, makeDelegateTaskWithInputs(
+									id, outpointAt(500_000+size*2+i),
+								)))
+							}
+
+							ids := interleaveIDs(first, last, size, "task-absent-"+u.name)
+							require.NoError(t, u.update(ids))
+
+							// Only assert on ids the batch could actually hold;
+							// a single-slot batch carries first alone.
+							updated := []string{first}
+							if size >= 2 {
+								updated = append(updated, last)
+							}
+							for _, id := range updated {
+								got, err := repo.GetByID(ctx, id)
+								require.NoError(t, err)
+								require.Equal(t, u.status, got.Status,
+									"status update must be applied across every chunk")
+							}
+
+							// A task that was never named must keep its status,
+							// so a chunked update cannot over-apply.
+							if size < 2 {
+								untouched, err := repo.GetByID(ctx, last)
+								require.NoError(t, err)
+								require.Equal(t, domain.DelegateTaskStatusPending, untouched.Status,
+									"tasks outside the id set must not be transitioned")
+							}
+						})
+					}
+				})
+			}
+		})
+	}
+}
+
+// interleaveIDs builds a slice of exactly size entries with first at the head and
+// last at the tail, padded in between with ids that do not exist in the store.
+func interleaveIDs(first, last string, size int, prefix string) []string {
+	if size <= 1 {
+		return []string{first}
+	}
+
+	ids := make([]string, 0, size)
+	ids = append(ids, first)
+	for i := 0; i < size-2; i++ {
+		ids = append(ids, fmt.Sprintf("%s-%d", prefix, i))
+	}
+	return append(ids, last)
+}

--- a/internal/infrastructure/db/bind_variable_limit_writes_test.go
+++ b/internal/infrastructure/db/bind_variable_limit_writes_test.go
@@ -72,8 +72,16 @@ func TestBindVariableLimitStatusUpdates(t *testing.T) {
 				},
 			}
 
-			for _, u := range updates {
+			for ui, u := range updates {
 				t.Run(u.name+" tasks over the bind variable limit", func(t *testing.T) {
+					// A task that is never named in any batch, so it pins the
+					// negative invariant at every size: a chunked update must not
+					// transition anything outside its id set.
+					bystander := fmt.Sprintf("boundary_%s_bystander", u.name)
+					require.NoError(t, repo.Add(ctx, makeDelegateTaskWithInputs(
+						bystander, outpointAt(900_000+ui),
+					)))
+
 					for _, size := range boundarySizes() {
 						t.Run(fmt.Sprintf("size=%d", size), func(t *testing.T) {
 							// Two real pending tasks: one first, one last. The
@@ -103,14 +111,21 @@ func TestBindVariableLimitStatusUpdates(t *testing.T) {
 									"status update must be applied across every chunk")
 							}
 
-							// A task that was never named must keep its status,
-							// so a chunked update cannot over-apply.
+							// The single-slot batch cannot carry last, so it doubles
+							// as a bystander for that size.
 							if size < 2 {
 								untouched, err := repo.GetByID(ctx, last)
 								require.NoError(t, err)
 								require.Equal(t, domain.DelegateTaskStatusPending, untouched.Status,
 									"tasks outside the id set must not be transitioned")
 							}
+
+							// Checked at every size, including the ones where
+							// chunking actually activates.
+							untouched, err := repo.GetByID(ctx, bystander)
+							require.NoError(t, err)
+							require.Equal(t, domain.DelegateTaskStatusPending, untouched.Status,
+								"a task outside the id set must not be transitioned")
 						})
 					}
 				})

--- a/internal/infrastructure/db/db_test.go
+++ b/internal/infrastructure/db/db_test.go
@@ -123,6 +123,8 @@ func testVHTLCRepository(t *testing.T, svc ports.RepoManager) {
 		testAddVHTLC(t, svc.VHTLC())
 		testGetAllVHTLC(t, svc.VHTLC())
 		testGetVHTLCsById(t, svc.VHTLC())
+		testGetVHTLCsByIdAcrossVariableBound(t, svc.VHTLC())
+		testGetVHTLCsByIdWithDuplicates(t, svc.VHTLC())
 		testAddNonInteractiveVHTLC(t, svc.VHTLC())
 	})
 }
@@ -304,6 +306,62 @@ func testGetVHTLCsById(t *testing.T, repo domain.VHTLCRepository) {
 		require.NoError(t, err)
 		require.Len(t, vhtlcList, 2)
 		require.Subset(t, []domain.Vhtlc{testVHTLC, secondVHTLC}, vhtlcList)
+	})
+}
+
+// The bound these cases straddle is sqliteMaxVariableNumber, declared alongside
+// the other boundary tests in bind_variable_limit_test.go.
+
+func testGetVHTLCsByIdAcrossVariableBound(t *testing.T, repo domain.VHTLCRepository) {
+	t.Run("get vHTLCs by ids across the sqlite variable bound", func(t *testing.T) {
+		known := make([]domain.Vhtlc, 0, 3)
+		knownIds := make([]string, 0, 3)
+		for i := 0; i < 3; i++ {
+			v := makeVHTLC()
+			require.NoError(t, repo.Add(ctx, v))
+			known = append(known, v)
+			knownIds = append(knownIds, v.Id)
+		}
+
+		for _, count := range []int{
+			sqliteMaxVariableNumber - 1,
+			sqliteMaxVariableNumber,
+			sqliteMaxVariableNumber + 1,
+			sqliteMaxVariableNumber*2 + 1,
+		} {
+			t.Run(fmt.Sprintf("%d ids", count), func(t *testing.T) {
+				ids := make([]string, 0, count)
+				ids = append(ids, knownIds...)
+				for len(ids) < count {
+					ids = append(ids, uuid.NewString())
+				}
+
+				got, err := repo.GetByIds(ctx, ids)
+				require.NoError(t, err)
+				require.Len(t, got, len(known))
+				require.Subset(t, known, got)
+			})
+		}
+	})
+}
+
+func testGetVHTLCsByIdWithDuplicates(t *testing.T, repo domain.VHTLCRepository) {
+	t.Run("get vHTLCs by ids returns each vHTLC once when ids repeat", func(t *testing.T) {
+		v := makeVHTLC()
+		require.NoError(t, repo.Add(ctx, v))
+
+		// Repeat the same id either side of a chunk boundary, so a chunked
+		// implementation would match it once per chunk.
+		ids := []string{v.Id}
+		for len(ids) < 2000 {
+			ids = append(ids, uuid.NewString())
+		}
+		ids = append(ids, v.Id)
+
+		got, err := repo.GetByIds(ctx, ids)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		require.Equal(t, v, got[0])
 	})
 }
 

--- a/internal/infrastructure/db/sqlite/chainswap_repo.go
+++ b/internal/infrastructure/db/sqlite/chainswap_repo.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"sort"
 
 	"github.com/ArkLabsHQ/fulmine/internal/core/domain"
 	"github.com/ArkLabsHQ/fulmine/internal/infrastructure/db/sqlite/sqlc/queries"
@@ -88,20 +89,32 @@ func (r *chainSwapRepository) GetByIDs(ctx context.Context, ids []string) ([]dom
 		return []domain.ChainSwap{}, nil
 	}
 
-	rows, err := r.querier.ListChainSwapsByIDs(ctx, ids)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list chain swaps by IDs: %w", err)
+	// Deduplicate first: a repeated id landing in two chunks would otherwise
+	// return the same swap twice, where a single statement returned it once.
+	ids = dedupeStrings(ids)
+
+	swaps := make([]domain.ChainSwap, 0)
+	for _, chunk := range chunkSlice(ids, maxBindVariablesPerStatement) {
+		rows, err := r.querier.ListChainSwapsByIDs(ctx, chunk)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list chain swaps by IDs: %w", err)
+		}
+
+		for _, row := range rows {
+			swap, err := toChainSwap(row)
+			if err != nil {
+				log.Warnf("failed to convert chain swap %s: %v", row.ID, err)
+				continue
+			}
+			swaps = append(swaps, *swap)
+		}
 	}
 
-	swaps := make([]domain.ChainSwap, 0, len(rows))
-	for _, row := range rows {
-		swap, err := toChainSwap(row)
-		if err != nil {
-			log.Warnf("failed to convert chain swap %s: %v", row.ID, err)
-			continue
-		}
-		swaps = append(swaps, *swap)
-	}
+	// ListChainSwapsByIDs orders by created_at DESC, but that only holds within a
+	// chunk. Restore the ordering the caller expects across the merged result.
+	sort.SliceStable(swaps, func(i, j int) bool {
+		return swaps[i].CreatedAt > swaps[j].CreatedAt
+	})
 
 	return swaps, nil
 }

--- a/internal/infrastructure/db/sqlite/chunk.go
+++ b/internal/infrastructure/db/sqlite/chunk.go
@@ -1,0 +1,64 @@
+package sqlitedb
+
+// maxBindVariablesPerStatement bounds how many caller-supplied values a single
+// statement may carry.
+//
+// Queries built with sqlc.slice() expand into one bind variable per element, and
+// SQLite refuses to prepare a statement with more variables than its compiled-in
+// SQLITE_MAX_VARIABLE_NUMBER (32766 in modernc.org/sqlite) — it fails with
+// "too many SQL variables". Some of those statements also bind fixed variables of
+// their own before the slice, so the usable headroom is not the raw limit.
+//
+// Rather than tracking per-query headroom we stay far below the limit. It is also
+// under the 999 that SQLite used before 3.32, so the bound survives a driver or
+// build-flag change. Keeping it a fixed round number means every full chunk
+// produces an identical statement string, which the driver's statement cache can
+// reuse; only the trailing partial chunk differs.
+//
+// The statements that bind a fixed variable of their own before the slice
+// (SuccessDelegateTasks, FailDelegateTasks) sit one higher at 901, still far
+// under either ceiling.
+const maxBindVariablesPerStatement = 900
+
+// chunkSlice splits items into consecutive batches of at most size elements.
+// An empty input yields no batches, so callers iterating the result issue no
+// query at all for an empty slice.
+//
+// The batches alias items rather than copying it, so a caller that mutates a
+// batch mutates the input. Every caller here passes a slice of ids straight to a
+// query and never writes to it.
+func chunkSlice[T any](items []T, size int) [][]T {
+	if size <= 0 || len(items) == 0 {
+		return nil
+	}
+
+	chunks := make([][]T, 0, (len(items)+size-1)/size)
+	for start := 0; start < len(items); start += size {
+		end := start + size
+		if end > len(items) {
+			end = len(items)
+		}
+		chunks = append(chunks, items[start:end])
+	}
+
+	return chunks
+}
+
+// dedupeStrings returns values without repeats, preserving first-seen order.
+//
+// Callers use it for two distinct reasons: to keep a duplicated input from
+// straddling a chunk boundary and yielding the same row twice, and to restore a
+// SELECT DISTINCT that only held within a single statement.
+func dedupeStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, v := range values {
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+
+	return out
+}

--- a/internal/infrastructure/db/sqlite/chunk.go
+++ b/internal/infrastructure/db/sqlite/chunk.go
@@ -32,7 +32,10 @@ func chunkSlice[T any](items []T, size int) [][]T {
 		return nil
 	}
 
-	chunks := make([][]T, 0, (len(items)+size-1)/size)
+	// Round up as 1+(len-1)/size rather than (len+size-1)/size, which wraps
+	// negative for a size near math.MaxInt. The guard above keeps len(items)-1
+	// non-negative.
+	chunks := make([][]T, 0, 1+(len(items)-1)/size)
 	for start := 0; start < len(items); start += size {
 		end := start + size
 		if end > len(items) {

--- a/internal/infrastructure/db/sqlite/chunk_test.go
+++ b/internal/infrastructure/db/sqlite/chunk_test.go
@@ -1,0 +1,77 @@
+package sqlitedb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestChunkSlice(t *testing.T) {
+	t.Run("empty input yields no chunks", func(t *testing.T) {
+		require.Empty(t, chunkSlice([]string(nil), 3))
+		require.Empty(t, chunkSlice([]string{}, 3))
+	})
+
+	t.Run("non-positive size yields no chunks", func(t *testing.T) {
+		require.Empty(t, chunkSlice([]string{"a"}, 0))
+		require.Empty(t, chunkSlice([]string{"a"}, -1))
+	})
+
+	t.Run("splits without losing or reordering elements", func(t *testing.T) {
+		for _, total := range []int{1, 2, 3, 4, 5, 9, 10, 11} {
+			items := make([]int, total)
+			for i := range items {
+				items[i] = i
+			}
+
+			for _, size := range []int{1, 2, 3, 10} {
+				chunks := chunkSlice(items, size)
+
+				flat := make([]int, 0, total)
+				for i, chunk := range chunks {
+					require.LessOrEqual(t, len(chunk), size)
+					if i < len(chunks)-1 {
+						require.Len(t, chunk, size, "only the final chunk may be short")
+					}
+					require.NotEmpty(t, chunk, "chunks must never be empty")
+					flat = append(flat, chunk...)
+				}
+
+				require.Equal(t, items, flat,
+					fmt.Sprintf("total=%d size=%d must round-trip exactly", total, size),
+				)
+			}
+		}
+	})
+
+	t.Run("stays within the sqlite bind variable limit", func(t *testing.T) {
+		// The limit this bound exists to respect. Guards against someone raising
+		// maxBindVariablesPerStatement past what SQLite will prepare.
+		const sqliteMaxVariableNumber = 32766
+		require.Less(t, maxBindVariablesPerStatement, sqliteMaxVariableNumber)
+
+		items := make([]string, 100_000)
+		for _, chunk := range chunkSlice(items, maxBindVariablesPerStatement) {
+			require.LessOrEqual(t, len(chunk), maxBindVariablesPerStatement)
+		}
+	})
+}
+
+func TestDedupeStrings(t *testing.T) {
+	t.Run("preserves first-seen order", func(t *testing.T) {
+		require.Equal(
+			t,
+			[]string{"c", "a", "b"},
+			dedupeStrings([]string{"c", "a", "c", "b", "a", "c"}),
+		)
+	})
+
+	t.Run("passes through already-unique input", func(t *testing.T) {
+		require.Equal(t, []string{"a", "b"}, dedupeStrings([]string{"a", "b"}))
+	})
+
+	t.Run("returns an empty slice for empty input", func(t *testing.T) {
+		require.Empty(t, dedupeStrings(nil))
+	})
+}

--- a/internal/infrastructure/db/sqlite/chunk_test.go
+++ b/internal/infrastructure/db/sqlite/chunk_test.go
@@ -2,6 +2,7 @@ package sqlitedb
 
 import (
 	"fmt"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -43,6 +44,14 @@ func TestChunkSlice(t *testing.T) {
 				)
 			}
 		}
+	})
+
+	t.Run("a size larger than the input yields one chunk", func(t *testing.T) {
+		// math.MaxInt is the boundary for the capacity calculation: computing it
+		// as len(items)+size-1 wraps negative for any input of two or more.
+		require.Equal(t, [][]int{{0, 1}}, chunkSlice([]int{0, 1}, math.MaxInt))
+		require.Equal(t, [][]int{{0}}, chunkSlice([]int{0}, math.MaxInt))
+		require.Equal(t, [][]int{{0, 1, 2}}, chunkSlice([]int{0, 1, 2}, math.MaxInt))
 	})
 
 	t.Run("stays within the sqlite bind variable limit", func(t *testing.T) {

--- a/internal/infrastructure/db/sqlite/delegate_repo.go
+++ b/internal/infrastructure/db/sqlite/delegate_repo.go
@@ -154,8 +154,21 @@ func (r *delegateRepository) GetPendingTaskIDsByInputs(ctx context.Context, inpu
 	for i, input := range inputs {
 		outpoints[i] = input.String()
 	}
+	outpoints = dedupeStrings(outpoints)
 
-	return r.querier.GetPendingTaskIDsByInputs(ctx, outpoints)
+	taskIDs := make([]string, 0)
+	for _, chunk := range chunkSlice(outpoints, maxBindVariablesPerStatement) {
+		ids, err := r.querier.GetPendingTaskIDsByInputs(ctx, chunk)
+		if err != nil {
+			return nil, err
+		}
+		taskIDs = append(taskIDs, ids...)
+	}
+
+	// The query's SELECT DISTINCT only deduplicates within a single statement. A
+	// task whose inputs span two chunks is reported once per chunk, so restore
+	// the distinctness the caller relies on before returning.
+	return dedupeStrings(taskIDs), nil
 }
 
 func (r *delegateRepository) GetAll(ctx context.Context, status domain.DelegateTaskStatus, limit int, offset int) ([]domain.DelegateTask, error) {
@@ -238,7 +251,9 @@ func (r *delegateRepository) CancelTasks(ctx context.Context, ids ...string) err
 		return nil // Nothing to cancel
 	}
 
-	err := r.querier.CancelDelegateTasks(ctx, ids)
+	err := r.updateTasksInChunks(ctx, ids, func(q *queries.Queries, chunk []string) error {
+		return q.CancelDelegateTasks(ctx, chunk)
+	})
 	if err != nil {
 		return fmt.Errorf("failed to cancel delegate tasks: %w", err)
 	}
@@ -251,9 +266,11 @@ func (r *delegateRepository) CompleteTasks(ctx context.Context, commitmentTxid s
 		return nil
 	}
 
-	err := r.querier.SuccessDelegateTasks(ctx, queries.SuccessDelegateTasksParams{
-		CommitmentTxid: sql.NullString{String: commitmentTxid, Valid: commitmentTxid != ""},
-		Ids:            ids,
+	err := r.updateTasksInChunks(ctx, ids, func(q *queries.Queries, chunk []string) error {
+		return q.SuccessDelegateTasks(ctx, queries.SuccessDelegateTasksParams{
+			CommitmentTxid: sql.NullString{String: commitmentTxid, Valid: commitmentTxid != ""},
+			Ids:            chunk,
+		})
 	})
 	if err != nil {
 		return fmt.Errorf("failed to mark delegate tasks as done: %w", err)
@@ -267,15 +284,45 @@ func (r *delegateRepository) FailTasks(ctx context.Context, reason string, ids .
 		return nil
 	}
 
-	err := r.querier.FailDelegateTasks(ctx, queries.FailDelegateTasksParams{
-		FailReason: sql.NullString{String: reason, Valid: len(reason) > 0},
-		Ids:        ids,
+	err := r.updateTasksInChunks(ctx, ids, func(q *queries.Queries, chunk []string) error {
+		return q.FailDelegateTasks(ctx, queries.FailDelegateTasksParams{
+			FailReason: sql.NullString{String: reason, Valid: len(reason) > 0},
+			Ids:        chunk,
+		})
 	})
 	if err != nil {
 		return fmt.Errorf("failed to mark delegate tasks as failed: %w", err)
 	}
 
 	return nil
+}
+
+// updateTasksInChunks applies a status update across ids in batches small enough
+// to stay under the sqlite bind-variable limit.
+//
+// Every batch runs inside one transaction. These are terminal state transitions,
+// so a partially applied update would leave the task set split between the old
+// and new status with nothing recording where it stopped — the caller would see
+// an error but have no way to tell which tasks it still owns. All-or-nothing
+// keeps a retry safe.
+//
+// Note that the statements behind CompleteTasks and FailTasks bind a leading
+// variable of their own (commitment txid / fail reason) before the id list, so
+// their usable headroom is one lower than CancelTasks'. The chunk size sits far
+// enough below the limit that the difference does not matter.
+func (r *delegateRepository) updateTasksInChunks(
+	ctx context.Context, ids []string, apply func(*queries.Queries, []string) error,
+) error {
+	ids = dedupeStrings(ids)
+
+	return execTx(ctx, r.db, func(querierWithTx *queries.Queries) error {
+		for _, chunk := range chunkSlice(ids, maxBindVariablesPerStatement) {
+			if err := apply(querierWithTx, chunk); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 }
 
 func (r *delegateRepository) Close() {

--- a/internal/infrastructure/db/sqlite/delegate_repo.go
+++ b/internal/infrastructure/db/sqlite/delegate_repo.go
@@ -160,7 +160,7 @@ func (r *delegateRepository) GetPendingTaskIDsByInputs(ctx context.Context, inpu
 	for _, chunk := range chunkSlice(outpoints, maxBindVariablesPerStatement) {
 		ids, err := r.querier.GetPendingTaskIDsByInputs(ctx, chunk)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to get pending task ids by inputs: %w", err)
 		}
 		taskIDs = append(taskIDs, ids...)
 	}

--- a/internal/infrastructure/db/sqlite/vhtlc_repo.go
+++ b/internal/infrastructure/db/sqlite/vhtlc_repo.go
@@ -63,18 +63,30 @@ func (r *vhtlcRepository) Get(ctx context.Context, id string) (*domain.Vhtlc, er
 	return &vhtlc, nil
 }
 
+// GetByIds returns the vHTLCs matching ids, each at most once, in no particular
+// order. Ids with no stored vHTLC are skipped. The lookup runs as several
+// statements, and an error from any one of them fails the whole call rather than
+// returning a partial set.
 func (r *vhtlcRepository) GetByIds(ctx context.Context, ids []string) ([]domain.Vhtlc, error) {
-	rows, err := r.querier.ListVHTLCsByID(ctx, ids)
-	if err != nil {
-		return nil, err
-	}
-	out := make([]domain.Vhtlc, 0, len(rows))
-	for _, row := range rows {
-		vhtlcs, err := toVhtlc(row)
+	// Deduplicate first: a repeated id landing in two chunks would otherwise
+	// return the same vHTLC twice, where a single statement returned it once.
+	ids = dedupeStrings(ids)
+
+	// Not presized on len(ids): the caller controls that, and the result is
+	// bounded by the rows that actually exist.
+	out := make([]domain.Vhtlc, 0)
+	for i, chunk := range chunkSlice(ids, maxBindVariablesPerStatement) {
+		rows, err := r.querier.ListVHTLCsByID(ctx, chunk)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to list vHTLCs for id chunk %d: %w", i, err)
 		}
-		out = append(out, vhtlcs)
+		for _, row := range rows {
+			vhtlcs, err := toVhtlc(row)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert vHTLC %s: %w", row.ID, err)
+			}
+			out = append(out, vhtlcs)
+		}
 	}
 	return out, nil
 }


### PR DESCRIPTION
Consolidates id-set batching across the sqlite repositories into a shared helper, and applies status-update batches in a single transaction.

Covered by the existing repository suite against both the sqlite and badger backends, plus unit tests for the helper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database queries involving large ID lists to work reliably within SQLite limits.
  * Prevented duplicate results when IDs or outpoints are repeated.
  * Preserved expected result ordering across batched queries.
  * Ensured bulk task status updates apply consistently across all records while maintaining transactional behavior.

* **Tests**
  * Added coverage for large, boundary-size, multi-batch, duplicate, and empty-input scenarios across supported database operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->