### PR TITLE
Add FULMINE_AUTO_INIT to create and unlock the wallet on first boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,14 @@ All settings are read from environment variables prefixed with `FULMINE_`. The m
 | `FULMINE_UNLOCKER_FILE_PATH` | Path to a file containing the wallet password (when using the `file` unlocker) | Not set |
 | `FULMINE_UNLOCKER_PASSWORD` | Wallet password (when using the `env` unlocker) | Not set |
 
+#### Auto-init (see [Auto-Init Feature](#-auto-init-feature))
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `FULMINE_AUTO_INIT` | Create and unlock the wallet automatically on first boot; requires an unlocker and `FULMINE_ARK_SERVER` | `false` |
+| `FULMINE_MNEMONIC` | 12-word BIP39 mnemonic to restore during auto-init; omit to generate a new one | Not set |
+| `FULMINE_MNEMONIC_FILE_PATH` | Path to a file containing the mnemonic to restore during auto-init (mutually exclusive with `FULMINE_MNEMONIC`) | Not set |
+
 #### Delegate (see [Running as a Delegate](#-running-as-a-delegate))
 
 | Variable | Description | Default |
@@ -148,12 +156,36 @@ Fulmine supports automatic wallet unlocking on startup, which is useful for unat
    FULMINE_UNLOCKER_PASSWORD=your_wallet_password
    ```
 
-Auto-unlock only runs if a wallet already exists; you must create the wallet once first.
+Auto-unlock only runs if a wallet already exists; you must create the wallet once first, or let [auto-init](#-auto-init-feature) create it for you on first boot.
 
 ⚠️ **Security Warning**: When using the auto-unlock feature, ensure your password is stored securely:
 - For file-based unlocking, use appropriate file permissions (chmod 600)
 - For environment-based unlocking, be cautious about environment variable visibility
 - Consider using Docker secrets or similar tools in production environments
+
+### 🚀 Auto-Init Feature
+
+With `FULMINE_AUTO_INIT=true`, Fulmine creates the wallet by itself on first boot, so a fresh instance becomes fully operational from a single command — no `genseed`/`create`/`unlock` calls and no web UI visit needed. Auto-init requires an [unlocker](#-auto-unlock-feature) (the wallet is created with the unlocker's password and unlocked right after) and `FULMINE_ARK_SERVER`.
+
+On the very first boot, Fulmine generates a new mnemonic and **prints it to stdout exactly once**, clearly marked as a backup prompt:
+
+```
+==========================================================================
+
+  FULMINE WALLET CREATED - BACK UP YOUR MNEMONIC NOW
+
+      word1 word2 ... word12
+
+  ...
+
+==========================================================================
+```
+
+Run `docker logs <container>` right after the first start and store the mnemonic offline. It is never printed again: the data directory only holds it encrypted with your wallet password.
+
+To restore an existing wallet instead of generating a new one (for example when re-provisioning a crashed machine), pass the mnemonic via `FULMINE_MNEMONIC` or, preferably, a mounted secret file via `FULMINE_MNEMONIC_FILE_PATH`. Nothing is printed in that case, and if the data directory already contains a *different* wallet, Fulmine refuses to start rather than serve the wrong identity.
+
+If a wallet already exists, auto-init does nothing and startup behaves exactly as before (auto-unlock only).
 
 ## 🤝 Running as a Delegate
 
@@ -162,18 +194,22 @@ A **delegate** is a Fulmine instance that refreshes other users' VTXOs on their 
 ### Requirements
 
 - **The delegate is disabled by default.** Enable it with `FULMINE_DELEGATE_ENABLED=true`.
-- **A delegate needs a created _and unlocked_ wallet.** The delegate service starts when the wallet is unlocked and stops when it is locked, and it signs batch transactions with the wallet's key. For unattended operation, configure [auto-unlock](#-auto-unlock-feature).
+- **A delegate needs a created _and unlocked_ wallet.** The delegate service starts when the wallet is unlocked and stops when it is locked, and it signs batch transactions with the wallet's key. For unattended operation, configure [auto-init](#-auto-init-feature) and [auto-unlock](#-auto-unlock-feature).
 - The delegate listens on its own port, `FULMINE_DELEGATE_PORT` (default `7002`), which **must differ** from the gRPC and HTTP ports.
 - Optionally set `FULMINE_DELEGATE_FEE` (satoshis) to require a service fee; clients must pay at least this amount to the delegate's address in their intent.
 
 ### Example
 
+This single command brings up a fully working delegate — [auto-init](#-auto-init-feature) creates and unlocks the wallet on first boot, no follow-up API calls needed:
+
 ```bash
 docker run -d \
   --name fulmine-delegate \
+  --restart unless-stopped \
   -p 7000:7000 \
   -p 7001:7001 \
   -p 7002:7002 \
+  -e FULMINE_AUTO_INIT=true \
   -e FULMINE_DELEGATE_ENABLED=true \
   -e FULMINE_DELEGATE_FEE=1000 \
   -e FULMINE_ARK_SERVER="https://server.example.com" \
@@ -184,7 +220,11 @@ docker run -d \
   ghcr.io/arklabshq/fulmine:latest
 ```
 
-Create and unlock the wallet once (see [Wallet Setup & Basic Usage](#-wallet-setup--basic-usage)); after that, auto-unlock brings the delegate back up on every restart.
+⚠️ **Back up before onboarding users**: the first boot prints the wallet mnemonic to stdout exactly once — run `docker logs fulmine-delegate` right away and store it offline. The mnemonic is the delegate's signing identity: clients embed the delegate's pubkey in their VTXOs, so losing it means the delegate can no longer serve any of its outstanding delegations.
+
+To re-provision a delegate on a new machine with the same identity, add `-e FULMINE_MNEMONIC="<the 12 words>"` (or mount a secret file and set `FULMINE_MNEMONIC_FILE_PATH`) to the same command. Note that restoring the mnemonic recovers the identity and funds, but delegation tasks already accepted from clients live in the database inside the data directory — back up the `fulmine-data` volume as well if you want pending tasks to survive a machine loss.
+
+On every restart, auto-unlock brings the delegate back up automatically.
 
 ### Endpoints
 

--- a/README.md
+++ b/README.md
@@ -181,9 +181,11 @@ On the very first boot, Fulmine generates a new mnemonic and **prints it to stdo
 ==========================================================================
 ```
 
-Run `docker logs <container>` right after the first start and store the mnemonic offline. It is never printed again: the data directory only holds it encrypted with your wallet password.
+Run `docker logs <container>` right after the first start and store the mnemonic offline. It is never printed again: the data directory only holds it encrypted with your wallet password. Once it is backed up, scrub it from wherever the output was captured — container logs and any log aggregator that ingests them.
 
 To restore an existing wallet instead of generating a new one (for example when re-provisioning a crashed machine), pass the mnemonic via `FULMINE_MNEMONIC` or, preferably, a mounted secret file via `FULMINE_MNEMONIC_FILE_PATH`. Nothing is printed in that case, and if the data directory already contains a *different* wallet, Fulmine refuses to start rather than serve the wrong identity.
+
+⚠️ **Prefer the file path in production.** A mnemonic passed in `FULMINE_MNEMONIC` is visible to anything that can read the container's environment — `docker inspect`, `/proc/<pid>/environ`, orchestrator dashboards — for the life of the container. Fulmine drops its own copy once the wallet is up, but it cannot remove the value from the process environment. With `FULMINE_MNEMONIC_FILE_PATH` the secret stays in a file you control (`chmod 600`, a Docker/Kubernetes secret mount).
 
 If a wallet already exists, auto-init does nothing and startup behaves exactly as before (auto-unlock only).
 

--- a/cmd/fulmine/main.go
+++ b/cmd/fulmine/main.go
@@ -127,6 +127,10 @@ func main() {
 		log.WithError(err).Fatal("failed to init interface service")
 	}
 
+	// The mnemonic now lives in the interface service config, which clears it
+	// once the wallet is up; drop this copy so it is not retained here too.
+	cfg.Mnemonic = ""
+
 	log.RegisterExitHandler(svc.Stop)
 
 	log.Info("starting service...")

--- a/cmd/fulmine/main.go
+++ b/cmd/fulmine/main.go
@@ -81,10 +81,12 @@ func main() {
 	log.Info("starting fulmine...")
 
 	svcConfig := grpcservice.Config{
-		GRPCPort:     cfg.GRPCPort,
-		HTTPPort:     cfg.HTTPPort,
-		DelegatePort: cfg.DelegatePort,
-		WithTLS:      cfg.WithTLS,
+		GRPCPort:         cfg.GRPCPort,
+		HTTPPort:         cfg.HTTPPort,
+		DelegatePort:     cfg.DelegatePort,
+		WithTLS:          cfg.WithTLS,
+		AutoInit:         cfg.AutoInit,
+		AutoInitMnemonic: cfg.Mnemonic,
 	}
 
 	dbSvc, err := db.NewService(db.ServiceConfig{

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -24,6 +24,9 @@ Generated from `config Structure`. **Do not edit manually.**
 | `FULMINE_UNLOCKER_TYPE` | `` | `string` | Unlocker type: file or env |
 | `FULMINE_UNLOCKER_FILE_PATH` | `` | `string` | Path to the unlocker password file (file unlocker) |
 | `FULMINE_UNLOCKER_PASSWORD` | `` | `string` | Unlocker password (env unlocker) |
+| `FULMINE_AUTO_INIT` | `false` | `bool` | Create and unlock the wallet automatically on first boot; requires an unlocker and FULMINE_ARK_SERVER |
+| `FULMINE_MNEMONIC` | `` | `string` | 12-word BIP39 mnemonic to restore during auto-init; omit to generate a new one (mutually exclusive with FULMINE_MNEMONIC_FILE_PATH) |
+| `FULMINE_MNEMONIC_FILE_PATH` | `` | `string` | Path to a file containing the 12-word mnemonic to restore during auto-init |
 | `FULMINE_DISABLE_TELEMETRY` | `false` | `bool` | Disable telemetry |
 | `FULMINE_SWAP_TIMEOUT` | `15` | `uint32` | Swap timeout in seconds |
 | `FULMINE_OTEL_COLLECTOR_URL` | `` | `string` | OpenTelemetry collector URL; enables OTel export when set |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ import (
 	envunlocker "github.com/ArkLabsHQ/fulmine/internal/infrastructure/unlocker/env"
 	fileunlocker "github.com/ArkLabsHQ/fulmine/internal/infrastructure/unlocker/file"
 	"github.com/ArkLabsHQ/fulmine/pkg/macaroon"
+	"github.com/ArkLabsHQ/fulmine/utils"
 	"github.com/spf13/viper"
 )
 
@@ -44,6 +45,10 @@ type Config struct {
 	UnlockerType     string `mapstructure:"UNLOCKER_TYPE" envInfo:"Unlocker type: file or env"`
 	UnlockerFilePath string `mapstructure:"UNLOCKER_FILE_PATH" envInfo:"Path to the unlocker password file (file unlocker)"`
 	UnlockerPassword string `mapstructure:"UNLOCKER_PASSWORD" envInfo:"Unlocker password (env unlocker)"`
+
+	AutoInit         bool   `mapstructure:"AUTO_INIT" envDefault:"false" envInfo:"Create and unlock the wallet automatically on first boot; requires an unlocker and FULMINE_ARK_SERVER"`
+	Mnemonic         string `mapstructure:"MNEMONIC" envInfo:"12-word BIP39 mnemonic to restore during auto-init; omit to generate a new one (mutually exclusive with FULMINE_MNEMONIC_FILE_PATH)"`
+	MnemonicFilePath string `mapstructure:"MNEMONIC_FILE_PATH" envInfo:"Path to a file containing the 12-word mnemonic to restore during auto-init"`
 	DisableTelemetry bool   `mapstructure:"DISABLE_TELEMETRY" envDefault:"false" envInfo:"Disable telemetry"`
 	SwapTimeout      uint32 `mapstructure:"SWAP_TIMEOUT" envDefault:"15" envInfo:"Swap timeout in seconds"`
 	OtelCollectorURL string `mapstructure:"OTEL_COLLECTOR_URL" envInfo:"OpenTelemetry collector URL; enables OTel export when set"`
@@ -84,6 +89,11 @@ var (
 	UnlockerFilePath = "UNLOCKER_FILE_PATH"
 	UnlockerPassword = "UNLOCKER_PASSWORD"
 
+	// Auto-init configuration
+	AutoInit         = "AUTO_INIT"
+	Mnemonic         = "MNEMONIC"
+	MnemonicFilePath = "MNEMONIC_FILE_PATH"
+
 	defaultDatadir          = appDatadir("fulmine", false)
 	dbType                  = sqliteDb
 	defaultGRPCPort         = 7000
@@ -105,6 +115,7 @@ var (
 	defaultDelegatePort          = 7002
 	defaultDelegateFee           = 0
 	defaultDelegateEnabled       = false
+	defaultAutoInit              = false
 )
 
 func LoadConfig() (*Config, error) {
@@ -128,6 +139,7 @@ func LoadConfig() (*Config, error) {
 	viper.SetDefault(OtelPushInterval, defaultOtelPushInterval)
 	viper.SetDefault(DelegateFee, defaultDelegateFee)
 	viper.SetDefault(DelegateEnabled, defaultDelegateEnabled)
+	viper.SetDefault(AutoInit, defaultAutoInit)
 
 	// TODO: move to validate method
 	if err := initDatadir(); err != nil {
@@ -174,9 +186,16 @@ func LoadConfig() (*Config, error) {
 		DelegateFee:           viper.GetUint64(DelegateFee),
 		DelegateEnabled:       viper.GetBool(DelegateEnabled),
 		EmulatorPubkey:        viper.GetString(EmulatorPubkey),
+		AutoInit:              viper.GetBool(AutoInit),
+		Mnemonic:              viper.GetString(Mnemonic),
+		MnemonicFilePath:      viper.GetString(MnemonicFilePath),
 	}
 
 	if err := config.initUnlockerService(); err != nil {
+		return nil, err
+	}
+
+	if err := config.validateAutoInit(); err != nil {
 		return nil, err
 	}
 
@@ -211,6 +230,61 @@ func (c *Config) initUnlockerService() error {
 	}
 	c.unlocker = svc
 	return nil
+}
+
+func (c *Config) validateAutoInit() error {
+	if !c.AutoInit {
+		if len(c.Mnemonic) > 0 || len(c.MnemonicFilePath) > 0 {
+			return fmt.Errorf(
+				"FULMINE_MNEMONIC and FULMINE_MNEMONIC_FILE_PATH require FULMINE_AUTO_INIT=true",
+			)
+		}
+		return nil
+	}
+
+	if c.unlocker == nil {
+		return fmt.Errorf("auto-init requires an unlocker: set FULMINE_UNLOCKER_TYPE")
+	}
+	if len(c.ArkServer) <= 0 {
+		return fmt.Errorf("auto-init requires FULMINE_ARK_SERVER to be set")
+	}
+
+	mnemonic, err := resolveAutoInitMnemonic(c.Mnemonic, c.MnemonicFilePath)
+	if err != nil {
+		return err
+	}
+	c.Mnemonic = mnemonic
+	return nil
+}
+
+// resolveAutoInitMnemonic returns the mnemonic to restore during auto-init, taken
+// from the env value or read from the mnemonic file. An empty result means no
+// mnemonic was configured and a new one must be generated.
+func resolveAutoInitMnemonic(mnemonic, filePath string) (string, error) {
+	if len(mnemonic) > 0 && len(filePath) > 0 {
+		return "", fmt.Errorf("FULMINE_MNEMONIC and FULMINE_MNEMONIC_FILE_PATH are mutually exclusive")
+	}
+
+	if len(filePath) > 0 {
+		buf, err := os.ReadFile(filePath)
+		if err != nil {
+			return "", fmt.Errorf("failed to read mnemonic file: %w", err)
+		}
+		mnemonic = string(buf)
+	}
+
+	// bip39 seed derivation is whitespace- and case-sensitive: normalize so a
+	// quoted env value or a file with a trailing newline can't derive a
+	// different identity than the words the operator backed up.
+	mnemonic = strings.ToLower(strings.Join(strings.Fields(mnemonic), " "))
+	if len(mnemonic) <= 0 {
+		return "", nil
+	}
+
+	if err := utils.IsValidMnemonic(mnemonic); err != nil {
+		return "", fmt.Errorf("invalid auto-init mnemonic: %w", err)
+	}
+	return mnemonic, nil
 }
 
 func (c Config) MacaroonSvc() macaroon.Service {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,126 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+const validMnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+
+func TestResolveAutoInitMnemonic(t *testing.T) {
+	writeFile := func(t *testing.T, content string) string {
+		path := filepath.Join(t.TempDir(), "mnemonic")
+		require.NoError(t, os.WriteFile(path, []byte(content), 0600))
+		return path
+	}
+
+	t.Run("neither set returns empty", func(t *testing.T) {
+		mnemonic, err := resolveAutoInitMnemonic("", "")
+		require.NoError(t, err)
+		require.Empty(t, mnemonic)
+	})
+
+	t.Run("both set are mutually exclusive", func(t *testing.T) {
+		_, err := resolveAutoInitMnemonic(validMnemonic, writeFile(t, validMnemonic))
+		require.ErrorContains(t, err, "mutually exclusive")
+	})
+
+	t.Run("valid mnemonic from env", func(t *testing.T) {
+		mnemonic, err := resolveAutoInitMnemonic(validMnemonic, "")
+		require.NoError(t, err)
+		require.Equal(t, validMnemonic, mnemonic)
+	})
+
+	t.Run("mnemonic from file is normalized", func(t *testing.T) {
+		path := writeFile(t, "  Abandon abandon abandon\tabandon abandon abandon abandon abandon abandon abandon abandon about\r\n")
+		mnemonic, err := resolveAutoInitMnemonic("", path)
+		require.NoError(t, err)
+		require.Equal(t, validMnemonic, mnemonic)
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		_, err := resolveAutoInitMnemonic("", filepath.Join(t.TempDir(), "does-not-exist"))
+		require.ErrorContains(t, err, "failed to read mnemonic file")
+	})
+
+	t.Run("invalid mnemonic", func(t *testing.T) {
+		_, err := resolveAutoInitMnemonic("abandon abandon abandon", "")
+		require.ErrorContains(t, err, "invalid auto-init mnemonic")
+	})
+
+	t.Run("bad checksum", func(t *testing.T) {
+		_, err := resolveAutoInitMnemonic("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon", "")
+		require.ErrorContains(t, err, "invalid auto-init mnemonic")
+	})
+}
+
+func TestLoadConfigAutoInit(t *testing.T) {
+	load := func(t *testing.T, env map[string]string) (*Config, error) {
+		viper.Reset()
+		t.Setenv("FULMINE_DATADIR", t.TempDir())
+		t.Setenv("FULMINE_NO_MACAROONS", "true")
+		for k, v := range env {
+			t.Setenv(k, v)
+		}
+		return LoadConfig()
+	}
+
+	t.Run("auto-init requires an unlocker", func(t *testing.T) {
+		_, err := load(t, map[string]string{
+			"FULMINE_AUTO_INIT":  "true",
+			"FULMINE_ARK_SERVER": "http://localhost:7070",
+		})
+		require.ErrorContains(t, err, "requires an unlocker")
+	})
+
+	t.Run("auto-init requires ark server", func(t *testing.T) {
+		_, err := load(t, map[string]string{
+			"FULMINE_AUTO_INIT":         "true",
+			"FULMINE_UNLOCKER_TYPE":     "env",
+			"FULMINE_UNLOCKER_PASSWORD": "password",
+		})
+		require.ErrorContains(t, err, "requires FULMINE_ARK_SERVER")
+	})
+
+	t.Run("mnemonic requires auto-init", func(t *testing.T) {
+		_, err := load(t, map[string]string{
+			"FULMINE_MNEMONIC": validMnemonic,
+		})
+		require.ErrorContains(t, err, "require FULMINE_AUTO_INIT=true")
+	})
+
+	t.Run("valid auto-init without mnemonic", func(t *testing.T) {
+		cfg, err := load(t, map[string]string{
+			"FULMINE_AUTO_INIT":         "true",
+			"FULMINE_ARK_SERVER":        "http://localhost:7070",
+			"FULMINE_UNLOCKER_TYPE":     "env",
+			"FULMINE_UNLOCKER_PASSWORD": "password",
+		})
+		require.NoError(t, err)
+		require.True(t, cfg.AutoInit)
+		require.Empty(t, cfg.Mnemonic)
+	})
+
+	t.Run("valid auto-init with mnemonic", func(t *testing.T) {
+		cfg, err := load(t, map[string]string{
+			"FULMINE_AUTO_INIT":         "true",
+			"FULMINE_ARK_SERVER":        "http://localhost:7070",
+			"FULMINE_UNLOCKER_TYPE":     "env",
+			"FULMINE_UNLOCKER_PASSWORD": "password",
+			"FULMINE_MNEMONIC":          validMnemonic + "\n",
+		})
+		require.NoError(t, err)
+		require.True(t, cfg.AutoInit)
+		require.Equal(t, validMnemonic, cfg.Mnemonic)
+	})
+
+	t.Run("disabled auto-init is unchanged", func(t *testing.T) {
+		cfg, err := load(t, nil)
+		require.NoError(t, err)
+		require.False(t, cfg.AutoInit)
+	})
+}

--- a/internal/interface/grpc/autoinit.go
+++ b/internal/interface/grpc/autoinit.go
@@ -18,8 +18,9 @@ const (
 )
 
 // autoInit creates the wallet on first boot so a fresh instance becomes
-// operational without any manual genseed/create/unlock calls. The wallet is
-// left locked: the auto-unlock step that follows in Start() brings it up.
+// operational without any manual genseed/create/unlock calls. Whatever lock
+// state Setup leaves behind is handled by the autoUnlock step that follows in
+// Start(): UnlockNode guards on IsLocked, so it is safe either way.
 func (s *service) autoInit() error {
 	ctx := context.Background()
 
@@ -122,6 +123,9 @@ func formatMnemonicBanner(mnemonic string) string {
   identity and the delegate signing key: store them offline before
   onboarding users. To restore on a new machine, run the same command
   with FULMINE_MNEMONIC (or FULMINE_MNEMONIC_FILE_PATH) set.
+
+  Once backed up, scrub these words from wherever this output was
+  captured (container logs, log aggregators, terminal scrollback).
 
 ==========================================================================
 `, mnemonic)

--- a/internal/interface/grpc/autoinit.go
+++ b/internal/interface/grpc/autoinit.go
@@ -1,0 +1,128 @@
+package grpc_interface
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/ArkLabsHQ/fulmine/utils"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	autoInitMaxAttempts  = 6
+	autoInitInitialDelay = 2 * time.Second
+	autoInitMaxDelay     = 30 * time.Second
+)
+
+// autoInit creates the wallet on first boot so a fresh instance becomes
+// operational without any manual genseed/create/unlock calls. The wallet is
+// left locked: the auto-unlock step that follows in Start() brings it up.
+func (s *service) autoInit() error {
+	ctx := context.Background()
+
+	if s.appSvc.IsInitialized() {
+		log.Debug("wallet already initialized, skipping auto-init")
+		return nil
+	}
+
+	// An unlocker is guaranteed by config validation.
+	password, err := s.unlockerSvc.GetPassword(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get password from unlocker: %w", err)
+	}
+	if len(password) <= 0 {
+		return fmt.Errorf("unlocker returned an empty password")
+	}
+
+	mnemonic, generated, err := resolveSetupMnemonic(s.cfg.AutoInitMnemonic)
+	if err != nil {
+		return err
+	}
+
+	// The ark server may still be booting (e.g. compose startup race): retry
+	// with backoff before giving up. The mnemonic is fixed before the loop so
+	// every retry re-creates the same identity.
+	delay := autoInitInitialDelay
+	for attempt := 1; ; attempt++ {
+		err = s.appSvc.Setup(ctx, s.arkServer, password, mnemonic)
+		if err == nil {
+			break
+		}
+		if attempt >= autoInitMaxAttempts {
+			return fmt.Errorf(
+				"failed to initialize wallet after %d attempts: %w", autoInitMaxAttempts, err,
+			)
+		}
+		log.WithError(err).Warnf(
+			"auto-init attempt %d/%d failed, retrying in %s", attempt, autoInitMaxAttempts, delay,
+		)
+		time.Sleep(delay)
+		delay *= 2
+		if delay > autoInitMaxDelay {
+			delay = autoInitMaxDelay
+		}
+	}
+
+	log.Info("wallet auto-initialized")
+	if generated {
+		// The banner goes straight to stdout, never through the logger: it must
+		// not be suppressed by the log level nor shipped by any log hook.
+		fmt.Fprint(os.Stdout, formatMnemonicBanner(mnemonic))
+	}
+	return nil
+}
+
+// verifyConfiguredMnemonic ensures the configured restore mnemonic matches the
+// identity of the wallet found in the datadir, so an operator restoring a
+// backup can't run against the wrong wallet without noticing. The wallet must
+// be unlocked.
+func (s *service) verifyConfiguredMnemonic() error {
+	mnemonic, err := s.appSvc.Dump(context.Background())
+	if err != nil {
+		return fmt.Errorf("cannot verify FULMINE_MNEMONIC against the wallet identity: %w", err)
+	}
+	if normalizeMnemonic(mnemonic) != normalizeMnemonic(s.cfg.AutoInitMnemonic) {
+		return fmt.Errorf(
+			"FULMINE_MNEMONIC does not match the wallet found in the datadir: " +
+				"remove the mnemonic variable or point FULMINE_DATADIR to the matching wallet",
+		)
+	}
+	return nil
+}
+
+// resolveSetupMnemonic returns the configured mnemonic, or a freshly generated
+// one when none is configured.
+func resolveSetupMnemonic(configured string) (mnemonic string, generated bool, err error) {
+	if len(configured) > 0 {
+		return configured, false, nil
+	}
+	mnemonic, err = utils.GetNewMnemonic()
+	if err != nil {
+		return "", false, fmt.Errorf("failed to generate mnemonic: %w", err)
+	}
+	return mnemonic, true, nil
+}
+
+func normalizeMnemonic(mnemonic string) string {
+	return strings.ToLower(strings.Join(strings.Fields(mnemonic), " "))
+}
+
+func formatMnemonicBanner(mnemonic string) string {
+	return fmt.Sprintf(`
+==========================================================================
+
+  FULMINE WALLET CREATED - BACK UP YOUR MNEMONIC NOW
+
+      %s
+
+  These 12 words are shown ONCE and never again. They are the wallet
+  identity and the delegate signing key: store them offline before
+  onboarding users. To restore on a new machine, run the same command
+  with FULMINE_MNEMONIC (or FULMINE_MNEMONIC_FILE_PATH) set.
+
+==========================================================================
+`, mnemonic)
+}

--- a/internal/interface/grpc/autoinit.go
+++ b/internal/interface/grpc/autoinit.go
@@ -53,8 +53,12 @@ func (s *service) autoInit() error {
 			break
 		}
 		if attempt >= autoInitMaxAttempts {
+			// Name the ark server: an unreachable or misconfigured
+			// FULMINE_ARK_SERVER is the likeliest cause, and this error is the
+			// last thing an operator sees before the process exits.
 			return fmt.Errorf(
-				"failed to initialize wallet after %d attempts: %w", autoInitMaxAttempts, err,
+				"failed to initialize wallet with ark server %s after %d attempts: %w",
+				s.arkServer, autoInitMaxAttempts, err,
 			)
 		}
 		log.WithError(err).Warnf(

--- a/internal/interface/grpc/autoinit_test.go
+++ b/internal/interface/grpc/autoinit_test.go
@@ -1,0 +1,46 @@
+package grpc_interface
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ArkLabsHQ/fulmine/utils"
+	"github.com/stretchr/testify/require"
+)
+
+const testMnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+
+func TestResolveSetupMnemonic(t *testing.T) {
+	t.Run("configured mnemonic is echoed", func(t *testing.T) {
+		mnemonic, generated, err := resolveSetupMnemonic(testMnemonic)
+		require.NoError(t, err)
+		require.False(t, generated)
+		require.Equal(t, testMnemonic, mnemonic)
+	})
+
+	t.Run("empty generates a valid mnemonic", func(t *testing.T) {
+		mnemonic, generated, err := resolveSetupMnemonic("")
+		require.NoError(t, err)
+		require.True(t, generated)
+		require.NoError(t, utils.IsValidMnemonic(mnemonic))
+	})
+}
+
+func TestNormalizeMnemonic(t *testing.T) {
+	require.Equal(t,
+		normalizeMnemonic("Word  other\tthing\n"),
+		normalizeMnemonic("word other thing"),
+	)
+	require.NotEqual(t,
+		normalizeMnemonic("word other thing"),
+		normalizeMnemonic("word other things"),
+	)
+}
+
+func TestFormatMnemonicBanner(t *testing.T) {
+	banner := formatMnemonicBanner(testMnemonic)
+	require.Contains(t, banner, testMnemonic)
+	require.Contains(t, banner, "BACK UP YOUR MNEMONIC")
+	require.Contains(t, banner, "ONCE")
+	require.GreaterOrEqual(t, strings.Count(banner, "====="), 2)
+}

--- a/internal/interface/grpc/config.go
+++ b/internal/interface/grpc/config.go
@@ -11,6 +11,11 @@ type Config struct {
 	HTTPPort     uint32
 	DelegatePort uint32
 	WithTLS      bool
+	// AutoInit makes Start() create and unlock the wallet on first boot.
+	AutoInit bool
+	// AutoInitMnemonic is the mnemonic to restore during auto-init; empty means
+	// a new one is generated.
+	AutoInitMnemonic string
 }
 
 func (c Config) Validate() error {

--- a/internal/interface/grpc/service.go
+++ b/internal/interface/grpc/service.go
@@ -312,6 +312,12 @@ func (s *service) Start() error {
 		log.Infof("started Delegate server at %s", s.cfg.delegateAddress())
 	}
 
+	// The listeners above are already accepting connections while the wallet is
+	// created and unlocked below. That window is deliberate: it lets /healthz
+	// answer NOT_SERVING instead of refusing connections during the auto-init
+	// retries, and any request arriving before the wallet is ready is rejected
+	// by the readiness gate. If a step below fails, Start returns and the
+	// process exits, cutting whatever arrived in the meantime.
 	if s.cfg.AutoInit {
 		if err := s.autoInit(); err != nil {
 			return fmt.Errorf("auto-init failed: %w", err)
@@ -329,10 +335,18 @@ func (s *service) Start() error {
 		}
 	}
 
-	if s.cfg.AutoInit && s.cfg.AutoInitMnemonic != "" {
-		if err := s.verifyConfiguredMnemonic(); err != nil {
-			return err
+	if s.cfg.AutoInit {
+		if s.cfg.AutoInitMnemonic != "" {
+			if err := s.verifyConfiguredMnemonic(); err != nil {
+				return err
+			}
 		}
+		// Nothing reads the configured mnemonic past this point: drop the
+		// reference so it is not retained for the process lifetime. When it came
+		// from FULMINE_MNEMONIC the value still lives in the process environment,
+		// so this bounds the live set rather than erasing the secret — which is
+		// why FULMINE_MNEMONIC_FILE_PATH is the recommended way to supply it.
+		s.cfg.AutoInitMnemonic = ""
 	}
 
 	return nil

--- a/internal/interface/grpc/service.go
+++ b/internal/interface/grpc/service.go
@@ -40,6 +40,7 @@ type service struct {
 	delegateGrpcServer *grpc.Server
 	unlockerSvc        ports.Unlocker
 	macaroonSvc        macaroon.Service
+	arkServer          string
 	appStopCh          chan struct{}
 	feStopCh           chan struct{}
 	otelShutdown       func()
@@ -268,6 +269,7 @@ func NewService(
 		delegateGrpcServer: delegateGrpcServer,
 		unlockerSvc:        unlockerSvc,
 		macaroonSvc:        macaroonSvc,
+		arkServer:          arkServer,
 		appStopCh:          appStopCh,
 		feStopCh:           feStopCh,
 		otelShutdown:       otelShutdown,
@@ -310,9 +312,26 @@ func (s *service) Start() error {
 		log.Infof("started Delegate server at %s", s.cfg.delegateAddress())
 	}
 
+	if s.cfg.AutoInit {
+		if err := s.autoInit(); err != nil {
+			return fmt.Errorf("auto-init failed: %w", err)
+		}
+	}
+
 	if s.unlockerSvc != nil {
 		if err := s.autoUnlock(); err != nil {
+			if s.cfg.AutoInit {
+				// Auto-init promises a wallet that ends up unlocked: a created-but-locked
+				// delegate is not operational, and a restart retries only the unlock.
+				return fmt.Errorf("auto-unlock failed: %w", err)
+			}
 			log.Warnf("failed to auto-unlock: %v", err)
+		}
+	}
+
+	if s.cfg.AutoInit && s.cfg.AutoInitMnemonic != "" {
+		if err := s.verifyConfiguredMnemonic(); err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
Closes #468

## What

With `FULMINE_AUTO_INIT=true`, a fresh Fulmine instance creates its wallet by itself on first boot and ends up unlocked, so a headless delegate becomes fully operational from a single `docker run` — no manual `genseed`/`create`/`unlock` calls.

- **First boot**: the wallet is created with the unlocker's password and `FULMINE_ARK_SERVER`, then unlocked via the existing auto-unlock path. The generated mnemonic is printed to stdout exactly once inside a delimited backup banner (written directly to stdout, never through logrus, so log level/formatters/hooks can't suppress or ship it).
- **Restore / migration**: supply the backed-up mnemonic via `FULMINE_MNEMONIC` or `FULMINE_MNEMONIC_FILE_PATH` — nothing is printed, the value is normalized (bip39 seed derivation is whitespace- and case-sensitive), and startup fails loudly if the datadir already holds a wallet with a different identity.
- **Resilience**: wallet creation retries with bounded exponential backoff (6 attempts, 2s→30s) to survive compose races where arkd isn't up yet; exhausting retries is fatal so the container restart policy surfaces it. Under auto-init, an auto-unlock failure is also fatal (the feature promises an unlocked wallet).
- **Unchanged**: if a wallet already exists and no mnemonic is configured, startup behaves exactly as before. Config validation rejects `AUTO_INIT` without an unlocker or ark server, and mnemonic vars without `AUTO_INIT`.

## Changes

- `internal/config/config.go`: `FULMINE_AUTO_INIT`, `FULMINE_MNEMONIC`, `FULMINE_MNEMONIC_FILE_PATH` + validation and `resolveAutoInitMnemonic` helper; `docs/environment.md` regenerated.
- `internal/interface/grpc/autoinit.go` (new): bootstrap, banner, identity-mismatch check.
- `internal/interface/grpc/service.go` / `config.go`, `cmd/fulmine/main.go`: wiring in `Start()` before the existing auto-unlock step.
- Tests: `internal/config/config_test.go`, `internal/interface/grpc/autoinit_test.go`.
- README: one-command delegate quickstart, auto-init section, backup guidance (the mnemonic is the delegate identity; accepted delegation tasks live in `fulmine.db`, so back up the data volume for task continuity).

## Notes

- Retrying `Setup` is safe for the target failure: the SDK contacts the ark server before persisting anything, and the mnemonic is fixed before the retry loop so every attempt creates the same identity.
- Two failures pre-exist on `next` (verified on a pristine checkout, untouched here): `TestPermissions` fails because `GetPubKey` is missing from the permission maps (which also makes that RPC unreachable with macaroons on), and `internal/core/application` tests don't compile due to `fmt.Errorf` calls with `%w` but no argument in `getVHTLCKeyIndex` (`service.go:1156-1164`).

## Verification

- `go build ./...`, `go vet`, `gofmt` clean; unit tests pass in all touched packages.
- Smoke-tested the binary: both config-validation fatals fire; the retry loop was observed backing off against an unreachable ark server.
- Regtest happy path (banner-once, restart, restore round-trip, mismatch fatal) needs Docker and is left for a manual pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0133vQQApUZs4duBW29vf3qb