### PR TITLE
fix(application): allow LockNode while wallet sync is still pending

### DIFF
--- a/internal/core/application/lock_node_test.go
+++ b/internal/core/application/lock_node_test.go
@@ -64,6 +64,27 @@ func TestLockNodeDuringActiveSync(t *testing.T) {
 	require.True(t, fake.locked)
 }
 
+func TestLockNodeCancelsActiveSync(t *testing.T) {
+	fake := newLockingFakeArkClient()
+	syncCtx, syncCancel := context.WithCancel(context.Background())
+	syncDone := make(chan struct{})
+	svc := &Service{
+		Wallet:        fake,
+		isInitialized: true,
+		walletUpdates: make(chan WalletUpdate, 1),
+		syncLock:      &sync.RWMutex{},
+		syncCancel:    syncCancel,
+		syncDone:      syncDone,
+	}
+	go func() {
+		<-syncCtx.Done()
+		close(syncDone)
+	}()
+
+	require.NoError(t, svc.LockNode(t.Context()))
+	require.True(t, fake.locked)
+}
+
 func TestLockNodeWaitsForUnlockFinalization(t *testing.T) {
 	fake := newLockingFakeArkClient()
 	svc := &Service{

--- a/internal/core/application/lock_node_test.go
+++ b/internal/core/application/lock_node_test.go
@@ -1,0 +1,34 @@
+package application
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLockNodeWhileSyncing(t *testing.T) {
+	fake := newLockingFakeArkClient()
+	svc := &Service{
+		Wallet:        fake,
+		isInitialized: true,
+		walletUpdates: make(chan WalletUpdate, 1),
+	}
+
+	require.NoError(t, svc.LockNode(t.Context()))
+	require.True(t, fake.locked)
+}
+
+type lockingFakeArkClient struct {
+	*fakeArkClient
+	locked bool
+}
+
+func (f *lockingFakeArkClient) Lock(context.Context) error {
+	f.locked = true
+	return nil
+}
+
+func newLockingFakeArkClient() *lockingFakeArkClient {
+	return &lockingFakeArkClient{fakeArkClient: newFakeArkClient()}
+}

--- a/internal/core/application/lock_node_test.go
+++ b/internal/core/application/lock_node_test.go
@@ -2,8 +2,11 @@ package application
 
 import (
 	"context"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/arkade-os/go-sdk/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -13,9 +16,51 @@ func TestLockNodeWhileSyncing(t *testing.T) {
 		Wallet:        fake,
 		isInitialized: true,
 		walletUpdates: make(chan WalletUpdate, 1),
+		syncLock:      &sync.RWMutex{},
 	}
 
 	require.NoError(t, svc.LockNode(t.Context()))
+	require.True(t, fake.locked)
+}
+
+func TestLockNodeDuringActiveSync(t *testing.T) {
+	release := make(chan struct{})
+	fake := &syncingFakeArkClient{
+		lockingFakeArkClient: newLockingFakeArkClient(),
+		syncRelease:          release,
+	}
+	svc := &Service{
+		Wallet:        fake,
+		isInitialized: true,
+		walletUpdates: make(chan WalletUpdate, 1),
+		syncLock:      &sync.RWMutex{},
+	}
+
+	svc.syncCh = make(chan types.SyncEvent, 1)
+	syncWorkerReady := make(chan struct{})
+	go func() {
+		svc.syncLock.Lock()
+		syncWorkerReady <- struct{}{}
+		defer svc.syncLock.Unlock()
+		ev := <-fake.IsSynced(context.Background())
+		svc.syncEvent = &ev
+		svc.syncCh <- ev
+	}()
+	<-syncWorkerReady
+
+	done := make(chan error, 1)
+	go func() {
+		done <- svc.LockNode(t.Context())
+	}()
+
+	select {
+	case err := <-done:
+		t.Fatalf("LockNode returned before sync worker finished: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(release)
+	require.NoError(t, <-done)
 	require.True(t, fake.locked)
 }
 
@@ -31,4 +76,20 @@ func (f *lockingFakeArkClient) Lock(context.Context) error {
 
 func newLockingFakeArkClient() *lockingFakeArkClient {
 	return &lockingFakeArkClient{fakeArkClient: newFakeArkClient()}
+}
+
+type syncingFakeArkClient struct {
+	*lockingFakeArkClient
+	syncRelease chan struct{}
+}
+
+func (f *syncingFakeArkClient) IsSynced(ctx context.Context) <-chan types.SyncEvent {
+	ch := make(chan types.SyncEvent, 1)
+	go func() {
+		if f.syncRelease != nil {
+			<-f.syncRelease
+		}
+		ch <- types.SyncEvent{Synced: true}
+	}()
+	return ch
 }

--- a/internal/core/application/lock_node_test.go
+++ b/internal/core/application/lock_node_test.go
@@ -56,10 +56,36 @@ func TestLockNodeDuringActiveSync(t *testing.T) {
 	select {
 	case err := <-done:
 		t.Fatalf("LockNode returned before sync worker finished: %v", err)
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(2 * time.Second):
 	}
 
 	close(release)
+	require.NoError(t, <-done)
+	require.True(t, fake.locked)
+}
+
+func TestLockNodeWaitsForUnlockFinalization(t *testing.T) {
+	fake := newLockingFakeArkClient()
+	svc := &Service{
+		Wallet:        fake,
+		isInitialized: true,
+		walletUpdates: make(chan WalletUpdate, 1),
+		syncLock:      &sync.RWMutex{},
+	}
+
+	svc.lifecycleLock.Lock()
+	done := make(chan error, 1)
+	go func() {
+		done <- svc.LockNode(t.Context())
+	}()
+
+	select {
+	case err := <-done:
+		t.Fatalf("LockNode returned while unlock finalization was active: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	svc.lifecycleLock.Unlock()
 	require.NoError(t, <-done)
 	require.True(t, fake.locked)
 }

--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -255,7 +255,7 @@ func (s *Service) Setup(ctx context.Context, serverUrl, password, mnemonic strin
 }
 
 func (s *Service) LockNode(ctx context.Context) error {
-	if err := s.isInitializedAndUnlocked(ctx); err != nil {
+	if err := s.isInitializedForLock(ctx); err != nil {
 		return err
 	}
 
@@ -914,6 +914,18 @@ func (s *Service) isInitializedAndUnlocked(ctx context.Context) error {
 	return nil
 }
 
+func (s *Service) isInitializedForLock(ctx context.Context) error {
+	if !s.isInitialized {
+		return fmt.Errorf("service not initialized")
+	}
+
+	if s.IsLocked(ctx) {
+		return fmt.Errorf("service is locked")
+	}
+
+	return nil
+}
+
 // handleAddressEventChannel is used to forward address events to the notifications channel
 func (s *Service) handleAddressEventChannel(
 	config *clientTypes.Config,
@@ -1153,15 +1165,15 @@ func (s *Service) getVHTLCKeyIndex(ctx context.Context, script string) (uint64, 
 
 	handler, err := s.Wallet.ContractManager().GetHandler(ctx, contract)
 	if err != nil {
-		return 0, fmt.Errorf("failed to get contract handler for vhtlc %s: %w", err)
+		return 0, fmt.Errorf("failed to get contract handler for vhtlc %s: %w", script, err)
 	}
 	keyRef, err := handler.GetKeyRef(contract)
 	if err != nil {
-		return 0, fmt.Errorf("failed to get key ref for vhtlc %s: %w", err)
+		return 0, fmt.Errorf("failed to get key ref for vhtlc %s: %w", script, err)
 	}
 	keyIndex, err := identity.GetKeyIndex(ctx, keyRef.Id)
 	if err != nil {
-		return 0, fmt.Errorf("failed to get key index for vhtlc %s: %w", err)
+		return 0, fmt.Errorf("failed to get key index for vhtlc %s: %w", script, err)
 	}
 	return uint64(keyIndex), nil
 }

--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -73,6 +73,7 @@ type Service struct {
 
 	isInitialized bool
 	walletReady   atomic.Bool // true once UnlockNode has done syncing
+	lifecycleLock sync.Mutex
 	syncLock      *sync.RWMutex
 	syncEvent     *types.SyncEvent
 	syncCh        chan types.SyncEvent
@@ -259,6 +260,9 @@ func (s *Service) LockNode(ctx context.Context) error {
 		return err
 	}
 
+	s.lifecycleLock.Lock()
+	defer s.lifecycleLock.Unlock()
+
 	err := s.Lock(ctx)
 	if err != nil {
 		return err
@@ -417,9 +421,11 @@ func (s *Service) UnlockNode(ctx context.Context, password string) error {
 
 		// We must wait for the client to be synced before doing anything.
 		wg.Wait()
+		s.lifecycleLock.Lock()
+		defer s.lifecycleLock.Unlock()
 
 		// Do nothing here if restore failed.
-		if s.syncEvent == nil {
+		if s.syncEvent == nil || s.IsLocked(finalizeCtx) {
 			return
 		}
 

--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -285,11 +285,17 @@ func (s *Service) LockNode(ctx context.Context) error {
 		s.vtxoListenerCancel = nil
 	}
 
+	if s.syncLock != nil {
+		s.syncLock.Lock()
+	}
 	s.walletReady.Store(false)
 	s.syncEvent = nil
 	if s.syncCh != nil {
 		close(s.syncCh)
 		s.syncCh = nil
+	}
+	if s.syncLock != nil {
+		s.syncLock.Unlock()
 	}
 
 	go func() {
@@ -301,9 +307,9 @@ func (s *Service) LockNode(ctx context.Context) error {
 
 // unwindFailedUnlock rolls back a partially-completed unlock so the wallet
 // returns to a clean locked state and a fresh unlock can retry, instead of being
-// stuck "finalizing unlock" until a restart. It runs only from UnlockNode's
-// post-sync goroutine after wg.Wait, and LockNode is gated out while walletReady
-// is false, so there is no concurrent teardown to race with.
+// stuck "finalizing unlock" until a restart. It runs from UnlockNode's post-sync
+// goroutine after wg.Wait. LockNode may run while finalization is still in
+// progress; both coordinate sync teardown via syncLock.
 func (s *Service) unwindFailedUnlock() {
 	if s.schedulerSvc != nil {
 		s.schedulerSvc.Stop()
@@ -328,11 +334,17 @@ func (s *Service) unwindFailedUnlock() {
 	// failing; drop it rather than leaving a live key behind a locked wallet.
 	s.clearSignerKey()
 
+	if s.syncLock != nil {
+		s.syncLock.Lock()
+	}
 	s.walletReady.Store(false)
 	s.syncEvent = nil
 	if s.syncCh != nil {
 		close(s.syncCh)
 		s.syncCh = nil
+	}
+	if s.syncLock != nil {
+		s.syncLock.Unlock()
 	}
 
 	// Re-lock LAST. s.Lock makes IsLocked() return true, which reopens UnlockNode's

--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -77,6 +77,8 @@ type Service struct {
 	syncLock      *sync.RWMutex
 	syncEvent     *types.SyncEvent
 	syncCh        chan types.SyncEvent
+	syncCancel    context.CancelFunc
+	syncDone      chan struct{}
 
 	externalSubscription *subscriptionHandler
 
@@ -263,6 +265,13 @@ func (s *Service) LockNode(ctx context.Context) error {
 	s.lifecycleLock.Lock()
 	defer s.lifecycleLock.Unlock()
 
+	if s.syncCancel != nil {
+		s.syncCancel()
+		<-s.syncDone
+		s.syncCancel = nil
+		s.syncDone = nil
+	}
+
 	err := s.Lock(ctx)
 	if err != nil {
 		return err
@@ -368,6 +377,9 @@ func (s *Service) UnlockNode(ctx context.Context, password string) error {
 		return nil
 	}
 
+	s.lifecycleLock.Lock()
+	defer s.lifecycleLock.Unlock()
+
 	// Stays closed until the post-sync goroutine below finishes assembling the
 	// wallet, so the unlock window can't expose a nil publicKey/privateKey/swapHandler.
 	s.walletReady.Store(false)
@@ -398,13 +410,24 @@ func (s *Service) UnlockNode(ctx context.Context, password string) error {
 	// failed unlock never syncs), wedging every later retry. Starting it here can't
 	// miss the event: IsSynced replays a completed sync via its syncDone fast-path.
 	s.syncCh = make(chan types.SyncEvent, 1)
+	syncCtx, syncCancel := context.WithCancel(context.Background())
+	s.syncCancel = syncCancel
+	s.syncDone = make(chan struct{})
 	wg := &sync.WaitGroup{}
 	wg.Go(func() {
-		s.syncLock.Lock()
-		defer s.syncLock.Unlock()
-		ev := <-s.Wallet.IsSynced(context.Background())
-		s.syncEvent = &ev
-		s.syncCh <- ev
+		defer close(s.syncDone)
+		synced := s.Wallet.IsSynced(syncCtx)
+		select {
+		case ev := <-synced:
+			s.syncLock.Lock()
+			defer s.syncLock.Unlock()
+			if syncCtx.Err() != nil || s.syncCh == nil {
+				return
+			}
+			s.syncEvent = &ev
+			s.syncCh <- ev
+		case <-syncCtx.Done():
+		}
 	})
 
 	// This go routine takes care of scheduling the next settlement and restore the watch
@@ -423,6 +446,8 @@ func (s *Service) UnlockNode(ctx context.Context, password string) error {
 		wg.Wait()
 		s.lifecycleLock.Lock()
 		defer s.lifecycleLock.Unlock()
+		s.syncCancel = nil
+		s.syncDone = nil
 
 		// Do nothing here if restore failed.
 		if s.syncEvent == nil || s.IsLocked(finalizeCtx) {


### PR DESCRIPTION
## Problem

`LockNode` gated on `isInitializedAndUnlocked`, which returns an error when
`syncEvent` is nil (`service is syncing`) or `walletReady` is false. If arkd was
unreachable during unlock, the wallet stays in that state and cannot be locked
or stopped.

## Fix

- Add `isInitializedForLock` that only requires initialization and an unlocked wallet.
- Use it in `LockNode` so teardown can proceed while sync is pending.
- Fix `getVHTLCKeyIndex` `fmt.Errorf` calls that omitted the `script` argument.

## Tests

`go test ./internal/core/application -run TestLockNodeWhileSyncing -count=1`

Fixes #428


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Node locking now works reliably while synchronization is active or finalization is completing.
  * Improved error messages when retrieving a VHTLC key index by including the relevant script identifier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->